### PR TITLE
Linux/Unix: put process_player_name() after initializing the display …

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -613,16 +613,8 @@ int main(int argc, char *argv[])
 		argv[1] = NULL;
 	}
 
-
-	/* Process the player name */
-	process_player_name(TRUE);
-
-
-
 	/* Install "quit" hook */
 	quit_aux = quit_hook;
-
-
 
 #ifdef USE_XAW
 	/* Attempt to use the "main-xaw.c" support */
@@ -777,6 +769,8 @@ int main(int argc, char *argv[])
 	/* Make sure we have a display! */
 	if (!done) quit("Unable to prepare any 'display module'!");
 
+	/* Process the player name */
+	process_player_name(TRUE);
 
 	/* Hack -- If requested, display scores and quit */
 	if (show_score > 0) display_scores(0, show_score);


### PR DESCRIPTION
…modules so it doesn't cause a crash by prompting for the save file's name while Term is NULL