### PR TITLE
Linux/Unix: drop -m486 from default CFLAGS in makefile.std: not …

### DIFF
--- a/src/makefile.std
+++ b/src/makefile.std
@@ -135,7 +135,7 @@ JP_OPT= -D"JP" -D"EUC" -DDEFAULT_LOCALE="\"ja_JP.eucJP\""
 #CFLAGS = -Wall -O1 -pipe -g -D"USE_X11" -D"USE_GCU"
 #LIBS = -lX11 -lcurses -ltermcap
 
-CFLAGS = -Wall -O2  -fno-strength-reduce -m486 -pipe -g -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include
+CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include
 LIBS = -L/usr/X11R6/lib -lX11 -lncurses
 
 


### PR DESCRIPTION
…recognized by a modern compiler (gcc 10.2.1 on Debian 11; compiler defaults to building x86_64 code)