### PR TITLE
Linux/Unix: set HAVE_STDINT_H in makefile.std for platforms where …

### DIFF
--- a/src/makefile.std
+++ b/src/makefile.std
@@ -133,18 +133,18 @@ JP_OPT= -D"JP" -D"EUC" -DDEFAULT_LOCALE="\"ja_JP.eucJP\""
 # See "main-gcu.c" and "z-config.h" for some optional "curses" defines,
 # including "USE_GETCH" and "USE_CURS_SET".  Note that "z-config.h" will
 # attempt to "guess" at many of these flags based on your system.
-#
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_X11" -D"USE_GCU"
+
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11" -D"USE_GCU"
 #LIBS = -lX11 -lcurses -ltermcap
 
-CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include
+CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include
 LIBS = -L/usr/X11R6/lib -lX11 -lncurses
 
 
 ##
 ## Variation -- Compile for Linux
 ##
-#CFLAGS = -Wall -O2 -pipe -g -DANGBAND_2_8_1 -D"USE_XAW" -D"USE_GCU"
+#CFLAGS = -Wall -O2 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_XAW" -D"USE_GCU"
 #LIBS = -L/usr/X11R6/lib -lXaw -lXext -lSM -lICE -lXmu -lXt \
 #	-lX11 -lcurses
 
@@ -152,35 +152,35 @@ LIBS = -L/usr/X11R6/lib -lX11 -lncurses
 ##
 ## Variation -- Only support "main-x11.c" (not "main-gcu.c")
 ##
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_X11"
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11"
 #LIBS = -lX11
 
 
 ##
 ## Variation -- Only support "main-gcu.c" (not "main-x11.c")
 ##
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_GCU"
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_GCU"
 #LIBS = -lcurses -ltermcap
 
 
 ##
 ## Variation -- Use "main-xaw.c" instead of "main-x11.c"
 ##
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_XAW" -D"USE_GCU"
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_XAW" -D"USE_GCU"
 #LIBS = -lXaw -lXmu -lXt -lX11 -lcurses -ltermcap
 
 
 ##
 ## Variation -- Use "main-cap.c" instead of "main-gcu.c"
 ##
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_X11" -D"USE_CAP"
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11" -D"USE_CAP"
 #LIBS = -lX11 -ltermcap
 
 
 ##
 ## Variation -- Only work on simple vt100 terminals
 ##
-#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -D"USE_CAP" -D"USE_HARDCODE"
+#CFLAGS = -Wall -O1 -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_CAP" -D"USE_HARDCODE"
 
 
 ##
@@ -188,7 +188,7 @@ LIBS = -L/usr/X11R6/lib -lX11 -lncurses
 ##
 #CFLAGS = -I/usr/X11R6/include -I/usr/include/ncurses \
 #         -Wall -O2 -fomit-frame-pointer -m486 \
-#         -D"USE_X11" -D"USE_GCU"
+#         -DANGBAND_2_8_1 -D"USE_X11" -D"USE_GCU"
 #LIBS = -L/usr/X11R6/lib -lX11 -lncurses -ltermcap
 
 ##
@@ -244,13 +244,13 @@ LIBS = -L/usr/X11R6/lib -lX11 -lncurses
 ## Variation -- compile for FreeBSD
 ##
 # (for Japanese ver.)
-#CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -D"USE_X11" -D"JP" -D"EUC" -D"USE_GCU" -I/usr/X11R6/include -DUSE_NCURSES -DDEFAULT_LOCALE="\"ja_JP.EUC\""
+#CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11" -D"JP" -D"EUC" -D"USE_GCU" -I/usr/X11R6/include -DUSE_NCURSES -DDEFAULT_LOCALE="\"ja_JP.EUC\""
 #LIBS = -L/usr/X11R6/lib -lX11 -lncurses -lmytinfo -lxpg4
 
 ##
 ## Variation -- compile for other BSD-like OS
 ##
-#CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include -DSPECIAL_BSD
+#CFLAGS = -Wall -O2  -fno-strength-reduce -pipe -g -DANGBAND_2_8_1 -DHAVE_STDINT_H -D"USE_X11" $(JP_OPT) -D"USE_GCU" -I/usr/X11R6/include -DSPECIAL_BSD
 #LIBS = -L/usr/X11R6/lib -lX11 -lcurses
 
 


### PR DESCRIPTION
…stdint.h should be present; avoids hp regeneration problems in environments where long is a 64-bit type