### PR TITLE
Linux/Unix: adapt color handling from Angband 4.2.4 for gcu frontend;…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -585,6 +585,10 @@ int main(int argc, char *argv[])
 
 #ifdef USE_GCU
 				puts("  -mgcu    To use GCU (GNU Curses)");
+				puts("  --       Sub options");
+				puts("  -- -B    Use brighter bold characters");
+				puts("  -- -K    Keep the terminal's color table when changing colors");
+				puts("");
 #endif /* USE_GCU */
 
 #ifdef USE_CAP


### PR DESCRIPTION
… with the default colors and terminals with an extended color range, avoids white backgrounds in lit areas and parts of the stats panel and character screen; unsure if it affects the UI problems when run on angband.live.