### PR TITLE
Linux/Unix: use Angband 4.2.4's exact formula for color scaling when …

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -753,7 +753,7 @@ static errr Term_xtra_gcu_event(int v)
 
 static int scale_color(int i, int j, int scale)
 {
-   return (angband_color_table[i][j] * (scale - 1) + 127) / 256;
+   return (angband_color_table[i][j] * (scale - 1) + 127) / 255;
 }
 
 static int create_color(int i, int scale)


### PR DESCRIPTION
…keeping the terminal's color table; previous change had a botched attempt at an alternate scaling ((index * scale) / 256 would be the real alternative)