### PR TITLE
Linux/Unix: in makefile.std's distclean rule, don't issue an error if…

### DIFF
--- a/src/makefile.std
+++ b/src/makefile.std
@@ -287,7 +287,8 @@ clean:
 	-\rm -f *.bak *.o
 
 distclean: clean
-	-\rm -r ../.build
+	-\rm -f hengband ../hengband
+	-\rm -rf ../.build
 
 
 #


### PR DESCRIPTION
… ../.builld isn't there and also remove the built executable