### PR TITLE
Linux/Unix: relax assumption that a terminal window is at most 80 …

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1004,7 +1004,7 @@ static errr Term_wipe_gcu(int x, int y, int n)
    wmove(td->win, y, x);
 
    /* Clear to end of line */
-   if (x + n >= 80)
+   if (x + n >= td->t.wid)
    {
       wclrtoeol(td->win);
    }
@@ -1066,10 +1066,6 @@ static errr Term_text_gcu(int x, int y, int n, byte a, cptr s)
 {
    term_data *td = (term_data *)(Term->data);
 
-   int i;
-
-   char text[81];
-
 #ifdef USE_NCURSES_ACS
    /* do we have colors + 16 ? */
    /* then call special routine for drawing special characters */
@@ -1080,9 +1076,6 @@ static errr Term_text_gcu(int x, int y, int n, byte a, cptr s)
    }
 #endif
 
-   /* Obtain a copy of the text */
-   for (i = 0; i < n; i++) text[i] = s[i];    text[n] = 0;
-
    /* Move the cursor and dump the string */
    wmove(td->win, y, x);
 
@@ -1092,7 +1085,7 @@ static errr Term_text_gcu(int x, int y, int n, byte a, cptr s)
 #endif
 
    /* Add the text */
-   waddstr(td->win, text);
+   waddnstr(td->win, s, n);
 
 #ifdef A_COLOR
    if (can_use_color) wattrset(td->win, WA_NORMAL);


### PR DESCRIPTION
…characters wide in Term_wipe_gcu() and Term_text_gcu()

That's based on the screenshot ster posted, http://angband.oook.cz/forum/showpost.php?p=158737&postcount=27 , where it looks like the left subwindows are wider than 80 characters.  Other than that, I'm unsure of what might be breaking the Angband.live version; I'm not seeing similar problems running offline (macOS terminal using the current code and this change).