### PR TITLE
Resolve some warnings from gcc 10.2.1 that could have runtime impacts

### DIFF
--- a/src/autopick.c
+++ b/src/autopick.c
@@ -6165,7 +6165,7 @@ static bool do_editor_command(text_body_type *tb, int com_id)
 #ifdef JP
 			rp_ptr->E_title, cp_ptr->E_title,ap_ptr->E_title,
 #else
-			rp_ptr->title, cp_ptr->title,
+			rp_ptr->title, cp_ptr->title, ap_ptr->title,
 #endif
 			p_ptr->lev
 			);

--- a/src/bldg.c
+++ b/src/bldg.c
@@ -13491,10 +13491,10 @@ static bool reimu_fortune_teller()
                 "Reimu takes out a cape and a crystal ball."));
 
 	if(one_in_(25)) c_put_str(TERM_WHITE,_("面倒臭いわね・・", "So troublesome..."),8 , 6);
-	else if(one_in_(4)) c_put_str(TERM_WHITE,("なになに・・", "What is it..."),8 , 6);
-	else if(one_in_(3)) c_put_str(TERM_WHITE,("ほうほう・・", "Let's see..."),8 , 6);
-	else if(one_in_(2)) c_put_str(TERM_WHITE,("あらあら・・", "Oh, my..."),8 , 6);
-	else				c_put_str(TERM_WHITE,("ふむふむ・・", "Hmmm..."),8 , 6);
+	else if(one_in_(4)) c_put_str(TERM_WHITE,_("なになに・・", "What is it..."),8 , 6);
+	else if(one_in_(3)) c_put_str(TERM_WHITE,_("ほうほう・・", "Let's see..."),8 , 6);
+	else if(one_in_(2)) c_put_str(TERM_WHITE,_("あらあら・・", "Oh, my..."),8 , 6);
+	else				c_put_str(TERM_WHITE,_("ふむふむ・・", "Hmmm..."),8 , 6);
 
 	(void)inkey();
 

--- a/src/cmd3.c
+++ b/src/cmd3.c
@@ -46,13 +46,13 @@ void do_cmd_inven(void)
 	item_tester_full = FALSE;
 
 #ifdef JP
-	sprintf(out_val, "持ち物： 合計 %3d.%1d kg (限界の%ld%%) コマンド: ",
+	sprintf(out_val, "持ち物： 合計 %3d.%1d kg (限界の%lu%%) コマンド: ",
 	    (int)lbtokg1(p_ptr->total_weight) , (int)lbtokg2(p_ptr->total_weight) ,
-	    (long int)((p_ptr->total_weight * 100) / weight_limit()));
+	    (unsigned long)((p_ptr->total_weight * 100) / weight_limit()));
 #else
 	sprintf(out_val, "Inventory: carrying %3d.%1d kg (%ld%% of capacity). Command: ",
 	    (int)lbtokg1(p_ptr->total_weight), (int)lbtokg2(p_ptr->total_weight) ,
-	    (p_ptr->total_weight * 100) / weight_limit());
+	    (unsigned long)(p_ptr->total_weight * 100) / weight_limit());
 #endif
 
 

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -9780,7 +9780,7 @@ static void do_cmd_knowledge_stat(void)
 static void do_cmd_knowledge_quests_current(FILE *fff)
 {
 	char tmp_str[120];
-	char rand_tmp_str[120] = "\0";
+	char rand_tmp_str[200] = "\0";
 	char name[80];
 	monster_race *r_ptr;
 	int i;

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -10061,11 +10061,11 @@ void do_cmd_knowledge_quests_completed(FILE *fff, int quest_num[])
 		//v1.1.25 クエスト達成時間情報追加
 		if(quest[q_idx].comptime)
 		{
-			sprintf(str_time,"(%.2lu:%.2lu:%.2lu)", quest[q_idx].comptime/(60*60), (quest[q_idx].comptime/60)%60, quest[q_idx].comptime%60);
+			sprintf(str_time,"(%.2lu:%.2lu:%.2lu)", (unsigned long) quest[q_idx].comptime/(60*60), (unsigned long) (quest[q_idx].comptime/60)%60, (unsigned long) quest[q_idx].comptime%60);
 		}
 		else
 		{
-			sprintf(str_time,"");
+			str_time[0] = '\0';
 		}
 
 

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -10830,7 +10830,7 @@ void do_cmd_time(void)
 #endif
 
 
-	if (day < MAX_DAYS) sprintf(day_buf, "%d", day);
+	if (day >= 0 && day < MAX_DAYS) sprintf(day_buf, "%d", day);
 	else strcpy(day_buf, "*****");
 
 	/* Message */

--- a/src/cmd_junko.c
+++ b/src/cmd_junko.c
@@ -244,7 +244,7 @@ bool convert_item_to_mana(void)
 	long price;
 	object_type *o_ptr;
 	char o_name[MAX_NLEN];
-	char out_val[160];
+	char out_val[MAX_NLEN + 32];
 
 	cptr q, s;
 
@@ -273,7 +273,7 @@ bool convert_item_to_mana(void)
 	object_desc(o_name, o_ptr, (OD_OMIT_PREFIX | OD_NAME_ONLY));
 	o_ptr->number = old_number;
 
-	sprintf(out_val, "%sは消滅します。よろしいですか？", o_name);
+	sprintf(out_val, _("%sは消滅します。よろしいですか？", "%s will disappear.  Is that OK? "), o_name);
 	if (!get_check_strict(out_val, CHECK_OKAY_CANCEL)) return FALSE;
 
 	price = object_value_real(o_ptr);

--- a/src/files.c
+++ b/src/files.c
@@ -7782,7 +7782,7 @@ static void dump_aux_class_special(FILE *fff)
 			{	} //壁生成などは内部的にダメージ値が記録されているが使わないので表示しない
 			else if (art_idx == JKF1_ATTACK_BREATH)
 				fprintf(fff, _("  威力:現在HPの%d%%",
-                                " Power:%d% of cur HP"), xtra1);
+                                " Power:%d%% of cur HP"), xtra1);
 			else if (dice && sides && base)
 				fprintf(fff, _("  威力/効果:%dd%d+%d",
                                 " Power/Eff:%dd%d+%d"), dice, sides, base);

--- a/src/files.c
+++ b/src/files.c
@@ -8730,7 +8730,7 @@ static void dump_aux_inventory2(FILE *fff)
 {
 	int i;
 	char o_name[MAX_NLEN];
-	char out_desc[MAX_NLEN];
+	char out_desc[24 + MAX_NLEN];
 	int inven2_num = calc_inven2_num();
 	object_type *o_ptr;
 	int pc = p_ptr->pclass;
@@ -9772,7 +9772,7 @@ prt("[キー:(?)ヘルプ (ESC)終了]", hgt - 1, 0);
 		{
 			FILE *ffp;
 			char buff[1024];
-			char xtmp[82];
+			char xtmp[162];
 
 			strcpy (xtmp, "");
 

--- a/src/files.c
+++ b/src/files.c
@@ -2603,6 +2603,7 @@ static void display_player_various(void)
 	if(alice)//ƒAƒŠƒX—×ÚUŒ‚‚Ì“Áêˆ—
 	{
 		blows1 = 0;
+		blows2 = 0;
 		damage[0] = 0;
 		for(i=0;i<INVEN_DOLL_NUM_MAX;i++)
 		{
@@ -2643,6 +2644,7 @@ static void display_player_various(void)
 		monster_race *r_ptr = &r_info[MON_EXTRA_FIELD];
 		damage[0] = 0;
 		blows1 = 0;
+		blows2 = 0;
 		for(i=0;i<4;i++)
 		{
 			if(!r_ptr->blow[i].method) continue;

--- a/src/flavor.c
+++ b/src/flavor.c
@@ -2586,7 +2586,7 @@ void object_desc(char *buf, object_type *o_ptr, u32b mode)
 			strcpy(temp, quark_str(o_ptr->art_name));
 
 		    if (o_ptr->tval == TV_MASK) {
-                t = object_desc_chr(t, ' of ');
+                t = object_desc_str(t, " of ");
                 t = object_desc_str(t, temp);
             } else if (o_ptr->tval == TV_PHOTO && o_ptr->sval == SV_PHOTO_NIGHTMARE) ;
 		    else {

--- a/src/init1.c
+++ b/src/init1.c
@@ -3424,7 +3424,8 @@ errr parse_d_info(char *buf, header *head)
 				s += 7;
 
 				/* Read a string */
-				strncpy(d_ptr->r_char, s, sizeof(d_ptr->r_char));
+				strncpy(d_ptr->r_char, s, sizeof(d_ptr->r_char) - 1);
+				d_ptr->r_char[sizeof(d_ptr->r_char) - 1] = '\0';
 
 				/* Start at next entry */
 				s = t;

--- a/src/mind.c
+++ b/src/mind.c
@@ -327,7 +327,7 @@ void mindcraft_info(char *p, int use_mind, int power)
 #ifdef JP
 	case 13: sprintf(p, " s“®:%ld‰ñ", (long int)(p_ptr->csp + 100-p_ptr->energy_need - 50)/100); break;
 #else
-	case 13: sprintf(p, " %ld acts.", (p_ptr->csp + 100-p_ptr->energy_need - 50)/100); break;
+	case 13: sprintf(p, " %ld acts.", (long int)(p_ptr->csp + 100-p_ptr->energy_need - 50)/100); break;
 #endif
 	}
       break;

--- a/src/scores.c
+++ b/src/scores.c
@@ -670,7 +670,7 @@ errr top_twenty(void)
 	//sprintf(the_score.pts, "%9ld", (long)total_points());
 	points = total_points_new(FALSE);
 	if (points > 999999999) points = 999999999;
-	sprintf(the_score.pts, "%9lu", points);
+	sprintf(the_score.pts, "%9lu", (unsigned long) points);
 	the_score.pts[9] = '\0';
 
 	/* Save the current gold */
@@ -803,7 +803,7 @@ msg_print("スコア・ファイルが使用できません。");
 	//sprintf(the_score.pts, "%9ld", (long)total_points());
 	score_point = total_points_new(FALSE);
 	if (score_point > 999999999) score_point = 999999999;
-	sprintf(the_score.pts, "%9ld", score_point);
+	sprintf(the_score.pts, "%9lu", (unsigned long) score_point);
 
 	/* Save the current gold */
 	sprintf(the_score.gold, "%9lu", (long)p_ptr->au);

--- a/src/wizard1.c
+++ b/src/wizard1.c
@@ -1484,7 +1484,7 @@ static void analyze_misc(object_type *o_ptr, char *misc_desc)
 #else
 	sprintf(misc_desc, "Level %u, Rarity %u, %d.%d lbs, %ld Gold",
 		a_ptr->level, a_ptr->rarity,
-		a_ptr->weight / 10, a_ptr->weight % 10, a_ptr->cost);
+		a_ptr->weight / 10, a_ptr->weight % 10, (long int)a_ptr->cost);
 #endif
 }
 


### PR DESCRIPTION
The only one that I've definitely seen symptoms of on Linux/Unix is the formatting of the inventory capacity.  The English translation issues (confirmation prompt for item to mana and use of the _() macro for the fortune teller strings) would have an impact on the Windows version.  I was looking for what might be causing the excessive screen redraws on angband.live when the monster list subwindow is used, but none of these look like the cause for that.