### PR TITLE
[linux] fix build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,11 @@
 # Base Heng ini file
 hengband.ini
 
-# Builds
+# Builds 
 *.exe
+.build/
+hengband
+src/hengband
 
 # Archives
 *.zip

--- a/README.md
+++ b/README.md
@@ -47,4 +47,7 @@ directories to the src subdirectory of the Touhou Katteban Hengband files, and
 run "make -f makefile.std".  The resulting executable is named "hengband" and
 is placed at the top level of the Touhou Katteban Hengband files.  To run it
 from a terminal, change directories to the top level of the Touhou Katteban
-Hengband files and run "./hengband".
+Hengband files and run "./hengband". Note that if you have your `MAKEFLAGS`
+environment variable set to use multiple jobs (-j2 or higher), there is a good 
+chance compilation will fail. If you encounter an error during compilation,
+consider using `unset MAKEFLAGS && make -f makefile.std` instead.

--- a/src/compile-wrap
+++ b/src/compile-wrap
@@ -56,7 +56,7 @@ for header in `find "$src_dir" -name '*.h' -print` "$src_dir"/maid-x11.c ; do
 	fi
 	if test -e "$dest_dir" ; then
 		if test ! -d "$dest_dir" ; then
-			rm "$dest_dir" || exit 1
+			rm -f "$dest_dir" || exit 1
 			mkdir "$dest_dir" || exit 1
 		fi
 	else
@@ -79,14 +79,14 @@ for header in `find "$src_dir" -name '*.h' -print` "$src_dir"/maid-x11.c ; do
 	dest_path="$dest_dir"/"$header_base"
 	if test $is_special -eq 0 ; then
 		if test -e "$dest_path" ; then
-			rm -r "$dest_path" || exit 1
+			rm -rf "$dest_path" || exit 1
 		fi
-		ln -s "$src_path" "$dest_path" || exit 1
+		ln -sf "$src_path" "$dest_path" || exit 1
 	elif test ! "$dest_path" -nt "$header" ; then
 		# Regenerate if it does not exist or is older than the header
 		# that is preprocessed to generate it.
 		if test -e "$dest_path" ; then
-			rm -r "$dest_path" || exit 1
+			rm -rf "$dest_path" || exit 1
 		fi
 		nkf -e "$header" > "$dest_path" || exit 1
 	fi
@@ -108,7 +108,7 @@ else
 fi
 if test -e "$dest_dir" ; then
 	if test ! -d "$dest_dir" ; then
-		rm "$dest_dir" || exit 1
+		rm -f "$dest_dir" || exit 1
 		mkdir "$dest_dir" || exit 1
 	fi
 else

--- a/src/makefile.std
+++ b/src/makefile.std
@@ -113,7 +113,7 @@ CC = gcc
 #
 # Options for Japanese version (comment out for English version)
 
-JP_OPT= -D"JP" -D"EUC" -DDEFAULT_LOCALE="\"ja_JP.eucJP\""
+#JP_OPT= -D"JP" -D"EUC" -DDEFAULT_LOCALE="\"ja_JP.eucJP\""
 
 ###################################################################
 


### PR DESCRIPTION
This PR addresses several concerns.

1). It fixes several failures in the `compile-wrap` script on linux where `ln` and `rm` need to have the `-f` flag to for compilation to proceed.
2). It defaults to commenting out the `JP_OPT` option from `makefile.std` (i.e. English version now default).
3). It adds Linux temporary files to the `.gitignore`.
4). It adds some documentation to the readme about avoiding a race condition in the makefile when compiling with parallel make (i.e. `-jN` N>1).