### PR TITLE
English: replace ideographic space with two standard spaces

### DIFF
--- a/src/bldg.c
+++ b/src/bldg.c
@@ -9929,7 +9929,7 @@ bool check_quest_unique_text(void)
 #else
                 strcpy(quest_text[line++], "Takane - 'Huh, a fairy? I'd like you to lend us a hand.");
 				strcpy(quest_text[line++], "  We're going to play danmaku with Reimu Hakurei!");
-				strcpy(quest_text[line++], "Å@Do you have power up items? Alright, go ahead!'");
+				strcpy(quest_text[line++], "  Do you have power up items? Alright, go ahead!'");
 #endif
 			}
 		}


### PR DESCRIPTION
That is the only instance I see where a non-ASCII character slipped into the English translation of the 2.0.18 changes.