### PR TITLE
Remaining monster translations, fix settings, wording changes

### DIFF
--- a/lib/edit/e_info.txt
+++ b/lib/edit/e_info.txt
@@ -191,7 +191,7 @@ C:10:10:0:3
 F:VORPAL | TUNNEL
 
 N:19:—•‘‚Μ
-E:of the Boisterous Dance
+E:of the Riotous Dance
 X:24:25
 W:0:24:0:12000
 C:0:0:0:3
@@ -220,7 +220,7 @@ W:0:24:0:8000
 F:BRAND_ACID | RES_ACID | IGNORE_ACID
 
 N:23:—‹b‚Μ
-E:of Raijuu
+E:of the Raijuu
 X:24:20
 W:0:18:0:4500
 F:BRAND_ELEC | RES_ELEC | IGNORE_ELEC
@@ -232,13 +232,13 @@ W:0:12:0:3000
 F:BRAND_FIRE | RES_FIRE | IGNORE_FIRE | LITE
 
 N:25:•XΈ‚Μ
-E:of Ice Fairies
+E:of the Ice Fairy
 X:24:15
 W:0:12:0:2500
 F:BRAND_COLD | RES_COLD | IGNORE_COLD
 
 N:26:ε…εn‚Μ
-E:of Centipede
+E:of the Centipede
 X:24:20
 W:0:24:0:8000
 C:8:8:0:2
@@ -441,7 +441,7 @@ F:RES_ACID | RES_ELEC | RES_FIRE | RES_COLD |
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD | XTRA_H_RES
 
 N:50:‹S_’·‚Μ
-E:of Kishin Lord
+E:of the Kishin Lord
 X:31:70
 W:0:80:0:44444
 C:5:5:10:3
@@ -452,7 +452,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 F:REGEN | SHOW_MODS
 
 N:51:–‚E_‚Μ
-E:of Makai God
+E:of the Makai God
 X:31:80
 W:0:240:0:66666
 C:0:0:30:4
@@ -505,7 +505,7 @@ F:RES_ACID | RES_ELEC | RES_FIRE | RES_COLD |
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD | XTRA_H_RES
 
 N:57:ƒIƒ‹ƒƒAƒ“‚Μ
-E:@Orlean
+E:@Orleans
 X:25:40
 W:0:96:0:25000
 C:0:0:20:0
@@ -634,7 +634,7 @@ W:0:24:0:0
 F:INT | WIS | CHR | NO_MAGIC
 
 N:73:βM‚θ_‚Μ
-E:of Scourge God
+E:of the Curse God
 X:33:0
 C:0:0:0:5
 W:0:18:0:0
@@ -673,7 +673,7 @@ F:STEALTH | XTRA_H_RES | XTRA_POWER
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 N:78:’n–ιλ‚Μ
-E:of Hell Raven
+E:of the Hell Raven
 X:32:20
 W:0:30:0:9000
 C:0:0:5:0
@@ -681,7 +681,7 @@ F:IGNORE_FIRE | SH_FIRE | RES_FIRE
 F:RES_LITE | RES_NETHER
 
 N:79:—³‹{‚Μg‚Ά‚Μ
-E:of Dragon Palace Messenger
+E:of the Dragon Palace Messenger
 X:32:20
 W:0:20:0:6000
 C:0:0:4:0
@@ -689,7 +689,7 @@ F:IGNORE_ELEC | SH_ELEC | RES_ELEC
 F:LEVITATION | XTRA_RES
 
 N:80:α—‚Μ
-E:of Yuki-Onna
+E:of the Yuki-Onna
 X:32:20
 W:0:20:0:3000
 C:0:0:4:0
@@ -697,7 +697,7 @@ F:SH_COLD | RES_COLD
 F:XTRA_POWER
 
 N:81:‹z‹S‚Μ
-E:of Vampire
+E:of the Vampire
 X:32:45
 W:0:100:0:30000
 C:5:5:0:5
@@ -705,7 +705,7 @@ F:SPEED | LEVITATION | RES_DARK | SEE_INVIS | INFRA | STEALTH | RES_NETHER
 F:SHOW_MODS
 
 N:82:“y’wε‚Μ
-E:of Tsuchigumo
+E:of the Tsuchigumo
 X:32:0
 W:0:48:0:0
 C:0:0:20:4
@@ -714,7 +714,7 @@ F:HEAVY_CURSE | CURSED | RES_POIS | RES_DARK
 F:RES_BLIND | FREE_ACT | RES_FEAR | SEE_INVIS
 
 N:83:•‚—V—μ‚Μ
-E:of Floating Spirits
+E:of the Wandering Ghost
 X:32:0
 W:0:8:0:0
 C:10:10:0:3
@@ -763,14 +763,14 @@ F:STR | SHOW_MODS | HIDE_TYPE | XTRA_H_RES
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 N:89:¬«–‚‚Μ
-E:of the Small Devil
+E:of the Imp
 X:34:20
 W:0:16:0:3000
 C:0:0:0:4
 F:MAGIC_MASTERY | HIDE_TYPE
 
 N:90:ƒLƒ‡ƒ“ƒV[‚Μ
-E:of Jiangshi
+E:of the Jiangshi
 X:34:0
 W:0:12:0:0
 C:0:0:0:5
@@ -778,7 +778,7 @@ F:INT | WIS | DEX | REGEN | RES_NETHER
 
 #ECC³‘ε•‘‰Α
 N:91:‹Φυ‚Μ
-E:of Taboo
+E:@Taboo
 X:34:0
 W:0:72:0:0
 C:0:0:50:0
@@ -822,7 +822,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 #‰B–§A‰Α‘¬‘‰Α—\’θ
 N:97:‰ΞΤ‚Μ
-E:of Kasha
+E:of the Kasha
 X:35:0
 W:0:48:0:0
 C:0:0:0:2
@@ -847,7 +847,7 @@ F:NO_TELE | RES_NETHER
 
 
 N:100:–ο_‚Μ
-E:of Misfortune God
+E:of the Misfortune God
 X:35:0
 W:0:48:0:0
 C:0:0:20:0
@@ -907,7 +907,7 @@ W:0:36:0:0
 C:0:0:0:0
 
 N:108:—HΊ‚Μ
-E:(Mysterious)
+E:@Occult
 X:30:20
 W:0:36:0:5000
 C:0:0:0:0
@@ -1012,14 +1012,14 @@ U:SPEED
 
 
 N:121:λl‚Μ
-E:of Hunter
+E:of the Hunter
 X:27:10
 W:30:0:0:8000
 C:0:0:0:3
 F:STEALTH
 
 N:122:ƒƒCƒh’·‚Μ
-E:of Chief Maid
+E:of the Chief Maid
 X:27:30
 W:30:0:0:2500
 C:0:0:0:3
@@ -1105,7 +1105,7 @@ C:0:0:0:0
 F:EASY_SPELL
 
 N:134:—΄_‚Μ
-E:of Dragon God
+E:of the Dragon God
 X:27:50
 W:100:0:0:100000
 C:0:0:20:5
@@ -1114,7 +1114,7 @@ F:ESP_EVIL
 U:ULTIMATE_RESIST
 
 N:135:Χ_‚Μ
-E:of Wicked God
+E:of the Wicked God
 X:27:50
 W:100:0:0:100000
 C:20:20:20:5
@@ -1130,7 +1130,7 @@ C:0:0:0:0
 F:DRAIN_EXP | CURSED | HEAVY_CURSE
 
 N:137:”ρ–\—Ν‚Μ
-E:of Pacifist
+E:of the Pacifist
 X:27:0
 W:0:0:0:0
 C:20:20:0:3
@@ -1165,7 +1165,7 @@ C:0:0:0:0
 F:TELEPORT
 
 N:142:ƒAƒ‹ƒrƒm‚Μ
-E:and Albino
+E:of the Albino
 X:27:0
 W:0:0:0:0
 C:0:0:20:3
@@ -1174,7 +1174,7 @@ F:CURSED | HEAVY_CURSE | CON
 
 ########################### Ego Amulet ####################
 N:143:εl‚Μ
-E:of Hermit
+E:of the Hermit
 X:29:5
 W:30:0:0:200
 C:0:0:0:3
@@ -1445,7 +1445,7 @@ C:0:0:0:0
 F:SPEED
 
 N:179:‹P‚­
-E:of Brilliance
+E:@Brilliant
 X:26:25
 W:60:60:0:15000
 C:0:0:0:0
@@ -1504,7 +1504,7 @@ F:CURSED | HEAVY_CURSE | TY_CURSE | AGGRAVATE
 F:RANDOM_CURSE2
 
 N:187:–@‹V®Ο‚έ…‹β’e“ª‚Μ
-E:of Mercury Bullets
+E:(Mercury Bullets)
 X:21:40
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 F:BLESSED
@@ -1548,7 +1548,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 F:RES_FIRE | RES_LITE | LEVITATION | LITE
 
 N:194:ƒ}ƒbƒhƒTƒCƒGƒ“ƒeƒBƒXƒg‚Μ
-E:of Mad Scientist
+E:of the Mad Scientist
 X:21:30
 W:15:40:0:16000
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
@@ -1563,7 +1563,7 @@ C:0:0:0:0
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 N:196:•n–R_‚Μ
-E:of Poverty
+E:of the Poverty God
 X:31:0
 W:0:48:0:0
 C:0:0:0:0
@@ -1578,7 +1578,7 @@ F:BRAND_ACID | IGNORE_ACID
 W:0:12:0:30
 
 N:198:“V’T—‚Μ
-E:of Track Deity
+E:of Ama-no-Sagume
 X:23:10
 F:SLAY_DEITY
 W:30:24:0:40
@@ -1586,7 +1586,7 @@ C:5:5:0:0
 
 #–Xq‚Μ‚έ
 N:199:’T’γ‚Μ
-E:@Detective
+E:of the Detective
 X:33:12
 W:0:32:0:2500
 C:0:0:0:4
@@ -1645,7 +1645,7 @@ C:0:0:15:4
 F:SAVING | XTRA_E_RES | XTRA_H_RES
 
 N:206:“V”n‚Μ
-E:of Celestial Steeds
+E:of the Celestial Steed
 X:35:60
 W:0:120:0:30000
 C:0:0:10:5
@@ -1714,7 +1714,7 @@ C:0:0:0:3
 F:CHR | XTRA_H_RES
 
 N:215:—ι—–‚Μ
-E:@Valley Lily
+E:@Lily-of-the-Valley
 X:20:20
 W:0:24:0:1500
 F:BRAND_POIS | RES_POIS

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -3728,6 +3728,7 @@ F:HURT_HOLY
 F:STAY_AT_HOME1
 S:1_IN_6
 S:DANMAKU
+D:$A familiar type of youkai often found in swamps and rivers. She is very wary.
 D:沼や川に多く住む身近な妖怪だ。警戒心が強い。
 
 #J0#
@@ -3938,6 +3939,8 @@ F:OPEN_DOOR | BASH_DOOR
 F:STAY_AT_HOME1
 S:1_IN_5
 S:BR_AQUA | DANMAKU
+D:$Kappa become much stronger when lurking in water, strong enough
+D:$to drag cattle or horses under.
 D:水中に潜む河童は力が増し、牛馬すら引きずり込むという。
 
 #J0#
@@ -3969,6 +3972,9 @@ F:HURT_HOLY
 F:WILD_MOUNTAIN | WILD_WOOD
 S:1_IN_4
 S:DANMAKU | SHOOT
+D:$A youkai that resembles a kappa but lives in the mountains, where
+D:$they have developed a sophisticated commercial system. Her hobby
+D:$seems to be playing at wilderness survival.
 D:河童に似た妖怪だ。山奥のアジトに暮らし、高度な商業システムを構築しているという。
 D:山の中でサバイバルゲームをすることが趣味のようだ。
 
@@ -5340,6 +5346,8 @@ F:STAY_AT_HOME1
 S:1_IN_5
 S:BO_WATE | DANMAKU | TRAPS | HOLD
 #TMP S:BEAM_LITE
+D:$A kappa wearing a large backpack from which various things
+D:$pop out like a jack-in-the-box.
 D:大きなリュックを背負った河童だ。リュックからはびっくり箱のように様々なものが飛び出す。
 
 
@@ -6580,7 +6588,8 @@ B:BITE:EXP_VAMP:6d6
 F:RAND_50 | COLD_BLOOD | REGENERATE | CAN_FLY | HURT_HOLY
 F:ANIMAL | IM_COLD | IM_POIS | RES_NETH | GEN_NEUTRAL
 F:NO_CONF | NO_SLEEP | NO_FEAR
-D:$ ...
+D:$A bat that has become a youkai in its search for human blood.
+D:$Vampires can also transform into these.
 D:人血を求めて妖怪化した大型の蝙蝠だ。吸血鬼が変身してこの姿になることもある。
 
 #J0#
@@ -12114,6 +12123,7 @@ F:OPEN_DOOR | BASH_DOOR | REGENERATE |
 F:IM_POIS | IM_COLD
 S:1_IN_6
 S:DANMAKU | ALARM
+D:$A tengu patrolwoman from the mountains.
 D:山で哨戒の役割を担う天狗だ。
 
 
@@ -16638,6 +16648,8 @@ F:IM_POIS | IM_COLD | IM_ELEC |
 S:1_IN_5
 S:DANMAKU | BA_FORCE | BO_MANA | SLOW | CONF | HOLD | BLIND | BLINK | TORNADO
 S:TPORT | HASTE | TELE_AWAY | TELE_APPROACH
+D:$A fast-moving tengu news reporter from the mountains.
+D:$She has significant sorcerous power and can fight in many ways.
 D:山で報道部隊の役割を担う素早い天狗だ。高い妖力を持ち多彩な攻撃をする。
 
 #JZ#
@@ -19649,7 +19661,7 @@ S:BR_SHAR | TELE_TO
 D:$This muscle-bound man with a horned helmet has won the Great Galaxy 
 D:$Bodybuiling championship ten times in a row. He is eager to prevent 
 D:$anyone from challenging his title. He's also known for his signature 
-D:$move, the Bo Emperor Building Cutter."
+D:$move, the Bo Emperor Building Cutter.
 D:銀河ボディビルコンテスト十連続グランドチャンピオン。
 D:必殺技はボ帝ビルカッター。
 
@@ -20031,7 +20043,7 @@ F:IM_FIRE | IM_ELEC | IM_ACID | IM_POIS | RES_HOLY
 F:NO_CONF | NO_SLEEP | NO_FEAR | FRIENDS
 F:ONLY_GOLD | DROP_90
 D:$An embodiment of various human desires.
-D:$This one seems to be derived from the desire for longevity.
+D:$This one seems to be derived from the desire for a long life.
 D:雑多な欲望の具現だ。長寿欲に関する神霊のようだ。
 
 N:985:ユニコーン
@@ -24172,7 +24184,7 @@ F:SMART | OPEN_DOOR |
 F:NO_CONF | NO_SLEEP | NO_FEAR
 S:1_IN_5 | 
 S:HEAL | PUNISH_3 |
-D:$"Repent, ye dead! Discover faith in death!" (Kentaro Miura, Berserk, chapter 20)
+D:$"Repent, ye dead! Discover faith in death!" (Kentaro Miura, Berserk, volume 20)
 D:「悔い改めよ亡者ども！信仰とは死ぬことと見つけたり！」　　(三浦建太郎　「ベルセルク」 20巻)
 
 #1202を倒すまでは通常出現しない
@@ -24193,7 +24205,7 @@ F:NO_CONF | NO_SLEEP | NO_FEAR | NO_STUN
 S:1_IN_4 | 
 S:BR_HOLY | BR_FIRE
 D:$"You fool who does not fear God, God's punishment is swift and certain! 
-D:$I will punish you on behalf of heaven!" (Kentaro Miura, Berserk, chapter 20)
+D:$I will punish you on behalf of heaven!" (Kentaro Miura, Berserk, volume 21)
 D:「神を畏れぬ愚か者よ　天罰覿面！　天に代わりてこの私が！あなたにバチを当てましょう！」
 D:　　(三浦建太郎　「ベルセルク」 20巻)
 
@@ -24663,6 +24675,7 @@ F:CHAMELEON | WILD_WOOD | DROP_2D2 | ANIMAL | GEN_KWAI
 F:IM_FIRE | IM_COLD | IM_ELEC | IM_ACID | IM_POIS |
 S:1_IN_1
 S:SPECIAL
+D:$Youkai foxes are famed for their transformation skills.
 D:狐の妖怪だ。その変身の技は有名である。
 
 
@@ -25088,8 +25101,8 @@ F:BASH_DOOR |
 F:ANIMAL | RIDING | CAN_SWIM | UNIQUE | ANG_FRIENDLY | STAY_AT_HOME2
 F:IM_ACID | IM_FIRE | IM_COLD | RES_WATE | WILD_OCEAN | WILD_SHORE | FORCE_MAXHP
 D:$Said to be a legendary monster fish.
-D:$'It is seven foot long, has a dark grey body, 6-inch long hair,
-D:$a rat-like head, red eyes, and a tail split like a swallow's...'
+D:$"It is seven foot long, has a dark grey body, 6-inch long hair,
+D:$a rat-like head, red eyes, and a tail split like a swallow's..."
 D:伝説の怪魚とされる。「長さ七尺、総身鼠色、毛の長さ七寸、頭鼠の如し、目赤し、尾は二股にして燕のごとし……」
 
 N:1260:送り提灯
@@ -25129,7 +25142,7 @@ F:NO_FEAR | NO_CONF
 S:1_IN_4 |
 S:TELE_HI_APPROACH | SHOOT | BLINK | TELE_TO | SPECIAL
 D:$A ninja feared as the Reaper of Neo-Saitama.
-D:$He wears red and black ninja attire and a sinister mask with the characters "Ninja" and "Kill" inscribed on each cheek.
+D:$He wears red and black ninja attire and a sinister mask with the characters "Nin" and "Kill" inscribed on each cheek.
 D:$His eyes burn with a desire for revenge against all ninjas.
 D:ネオサイタマの死神と恐れられるニンジャだ。
 D:赤黒の忍者装束を纏い、左右の頬に「忍」「殺」と刻まれた禍々しい仮面をつけている。
@@ -26624,6 +26637,9 @@ B:CLAW:HURT:1d5
 B:BITE:HURT:1d10
 F:OPEN_DOOR | WILD_SHORE | WILD_SWAMP | CAN_SWIM
 F:ANIMAL | WILD_ONLY| GEN_NEUTRAL| FRIENDS
+D:$An animal with short limbs and a slender elongated body.
+D:$It's good at swimming and is found near water.
+D:$Old otters are said to have powers of illusion.
 D:短い四肢と流れるように細長い胴体を持つ獣だ。泳ぎが得意で水辺に棲んでいる。
 D:年経たカワウソは化けて人を惑わすとされる。
 

--- a/src/birth.c
+++ b/src/birth.c
@@ -4479,7 +4479,7 @@ static bool get_player_class(void)
 #endif
 
 	cptr help_index[MAX_CLASS_CHOICE+1] =
-	{"Warrior","Mage","Shrine-Maiden","Explorer","Ranger","Protector",
+	{"Warrior","Mage","Shrine-Maiden","Explorer","Ranger","Guardian",
 	"Teacher","Maid","Martial-Artist","Mindcrafter","High-Mage","Civilian",
 	"Shugenja","Magic-Knight","Danmakulogist","Marksman","Magic-Eater","Engineer",
 	"Librarian","Samurai","Soldier","Chemist","Cavalry","Tsukumo-Master","Secondhand-Dealer","Jeweler",

--- a/src/files.c
+++ b/src/files.c
@@ -8778,7 +8778,7 @@ static void dump_aux_race_history(FILE *fff)
 	if(p_ptr->pclass == CLASS_MOKOU)
 	{
 		fprintf(fff, _("\n[ƒŠƒUƒŒƒNƒVƒ‡ƒ“‰ñ”] %d‰ñ\n",
-                        "\n[Times ressurected] %d time(s)\n"), p_ptr->magic_num1[0]);
+                        "\n[Times resurrected] %d time(s)\n"), p_ptr->magic_num1[0]);
 	}
 	if (p_ptr->pclass == CLASS_SHION)
 	{

--- a/src/new_class_power.c
+++ b/src/new_class_power.c
@@ -57,7 +57,7 @@ class_power_type class_power_zanmu[] =
 
 	{ 10,0,0,FALSE,FALSE,A_WIS,0,0,_("精神統一", "Concentrate Mind"),
 	_("精神を集中して魔力を回復する。",
-    "Concenctrates your mind, recovering MP.")},
+    "Concentrates your mind, recovering MP.")},
 
 	{ 15,25,35,FALSE,TRUE,A_INT,0,0,_("虚無操作Ⅰ", "Void Manipulation I"),
 	_("モンスター一体を高確率でフロアから追放する。クエスト打倒対象のモンスターには効果がない。",
@@ -76,7 +76,7 @@ class_power_type class_power_zanmu[] =
 
 	{ 35,80,70,FALSE,TRUE,A_INT,0,0,_("虚無操作Ⅲ", "Void Manipulation III"),
 	_("一時的に「未来予知」「レーダーセンス」を得る。",
-    "Temporarily gives effects of Foresight and Radar Sense.")},
+    "Temporarily gives effects of Future Sight and Radar Sense.")},
 
 	{ 40,160,80,FALSE,TRUE,A_CHR,0,0,_("亡羊のキングダム", "Kingdom of Lost Sheep"),
 	_("周囲の広範囲のモンスターを友好的にしようと試みる。クエスト打倒対象モンスターと精神を持たないモンスターには効果がない。",
@@ -10015,7 +10015,7 @@ cptr do_cmd_class_power_aux_narumi(int num, bool only_info)
 			}
 			if(cnt >= max_num)
 			{
-				msg_format(_("これ以上作り出せない。", "You can't creat any more."),num);
+				msg_format(_("これ以上作り出せない。", "You can't create any more."),num);
 				return NULL;
 			}
 
@@ -10169,7 +10169,7 @@ cptr do_cmd_class_power_aux_aunn(int num, bool only_info)
 		{
 			if(only_info) return format("");
 
-			msg_print(_("あなたは目まぐるしく跳ね回った！", "You spin arounding at blinding speed!"));
+			msg_print(_("あなたは目まぐるしく跳ね回った！", "You spin around at blinding speed!"));
 			whirlwind_attack(0);
 		}
 		break;
@@ -10263,7 +10263,7 @@ cptr do_cmd_class_power_aux_nemuno(int num, bool only_info)
 		{
 			object_type forge, *q_ptr = &forge;
 			if(only_info) return _("食料を生成", "create food");
-			msg_print(_("あなたは手際よく食物を集め始めた..", "You start carefully collection food..."));
+			msg_print(_("あなたは手際よく食物を集め始めた..", "You start carefully collecting food..."));
 			object_prep(q_ptr, lookup_kind(TV_FOOD, SV_FOOD_RATION));
 			q_ptr->discount = 99;
 			drop_near(q_ptr, -1, py, px);
@@ -21983,7 +21983,7 @@ class_power_type class_power_magic_eater[] =
 
 	{20,20,45,FALSE,TRUE,A_INT,0,0,_("魔力充填Ⅱ", "Replenish Magic II"),
 		_("体に取り込んだ杖・魔法棒・ロッドの使用回数を充填する。充填量にはレベル・知能・アイテムレベル・最大使用可能回数が影響し、高難度な魔道具は一度の充填では使用回数が増えないことがある。",
-        "Replenishes amount of charges of absorbed staves/wands/rods. Replenished amount depends on your level, charisma, item level and macimum amount of charges. High difficulty magic devices might not get replenished at all.")},
+        "Replenishes amount of charges of absorbed staves/wands/rods. Replenished amount depends on your level, charisma, item level and maximum amount of charges. High difficulty magic devices might not get replenished at all.")},
 
 	{30,30,60,FALSE,TRUE,A_INT,0,0,_("魔力充填Ⅲ", "Replenish Magic III"),
 		_("発動済みの装備品の充填時間を短縮する。",
@@ -23876,7 +23876,7 @@ cptr do_cmd_class_power_aux_nitori(int skillnum, bool only_info)
 			int damage = plev * 5 + chr_adj * 5;
 			if(only_info) return format(_str_eff_dam,damage);
 			msg_format(_("辺りは一瞬にして深い水の底になった。",
-                        "Your surroundings instantly become deeply flooded with water."));
+                        "Your surroundings instantly become flooded with deep water."));
 			project_hack2(GF_WATER_FLOW,0,0,2);
 			project_hack2(GF_WATER,0,0,damage);
 			p_ptr->update |= (PU_BONUS);
@@ -24057,7 +24057,7 @@ cptr do_cmd_class_power_aux_remy(int num, bool only_info)
 						if(r_ptr->flags3 & RF3_HUMAN)
 							msg_format(_("この血は最高に美味だ！", "This blood is the best!"));
 						else
-							msg_format(_("意外に悪くない味だ。", "That tasted surprisingly well."),m_name);
+							msg_format(_("意外に悪くない味だ。", "That tasted surprisingly good."),m_name);
 					}
 					else
 					{
@@ -24431,7 +24431,7 @@ class_power_type class_power_sanae[] =
         "Fires non-elemental bolts in a rapid succession. Requires at least 3rd level of chanting to Kanako. Amount of bolts increases with chant duration.")},
 	{ 7,5,20,FALSE,TRUE,A_WIS,0,1,_("コバルトスプレッド", "Cobalt Spread"),
 		_("障害物に当たると爆発する汚染属性の蛙の弾を放つ。詠唱(諏訪子)が3段階以上必要。詠唱が長いほど威力と爆発半径が上がる。",
-        "Fires a frog bullet that explodes into pollution when it hits an obstacled. Requires at least 3rd level of chanting to Suwako. Power and explosion radius increases with chant duration.")},
+        "Fires a frog bullet that explodes into pollution when it hits an obstacle. Requires at least 3rd level of chanting to Suwako. Power and explosion radius increases with chant duration.")},
 	{ 10,3,45,FALSE,FALSE,A_INT,0,0,_("霊的知覚", "Spiritual Perception"),
 		_("周囲のモンスターを感知する。レベルが上がると範囲が広がる。この技によって詠唱が途切れることはない。(失敗すると途切れる)",
         "Detects nearby monsters. Area of detection increases with your level. This ability does not interrupt chanting unless it fails.")},
@@ -26127,7 +26127,7 @@ class_power_type class_power_murasa[] =
         "Floods everything in sight, dealing water damage to enemies.")},
 	{46,72,75,FALSE,TRUE,A_CHR,0,0,_("ディープシンカー", "Deep Sinker"),
 		_("隣接した敵に強力な水属性攻撃を行い、非ユニークで水耐性のない生物を高確率で一撃で倒す。自分が深い水にいないと使えず、空を飛んでいる敵・力強い敵・巨大な敵には効きにくい。",
-        "Hits an adjacent enemy with a powerful water attack. Has a high chance of defeating non-unique living beins without water resistance in a single strike. Cannot be used unless standing in deep water, and less effective against flying, powerful or gigantic enemies.")},
+        "Hits an adjacent enemy with a powerful water attack. Has a high chance of defeating non-unique living beings without water resistance in a single strike. Cannot be used unless standing in deep water, and less effective against flying, powerful or gigantic enemies.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",
 		""},
@@ -27824,7 +27824,7 @@ cptr do_cmd_class_power_aux_toziko(int num, bool only_info)
 			if(use_itemcard)
 				msg_format(_("カードが激しく放電した！", "There is an intense electric discharge from the card!"));
 			else
-				msg_format(_("あなたは激しく放電した。", "You intensily discharge electricity."));
+				msg_format(_("あなたは激しく放電した。", "You intensely discharge electricity."));
 			project(0, rad, py, px, base, GF_ELEC, PROJECT_KILL | PROJECT_ITEM, -1);
 			break;
 		}
@@ -29431,7 +29431,7 @@ cptr do_cmd_class_power_aux_shou(int num, bool only_info)
 			if(sides < 1) sides = 1;
 			if(only_info) return format(_str_eff_dam_dice_sides,dice,sides);
 			msg_format(_("浄化の光が周囲を焼き尽くした！",
-                        "Purifying light scorches area around you!"));
+                        "Purifying light scorches the area around you!"));
 			project_hack2(GF_HOLY_FIRE,dice,sides,0);
 			break;
 		}
@@ -29492,7 +29492,7 @@ class_power_type class_power_flan[] =
         "Generates multiple powerful disintegration balls at random positions in your vicinity. Power increases as you current HP gets lower.")},
 	{50,-100,95,FALSE,TRUE,A_WIS,0,0,_("スカーレットニヒリティ", "Scarlet Nihility"),
 		_("MP全て(最低100)とアイテム「フォービドゥンフルーツ」を消費し、極めて強力な万能属性のボール攻撃を行う。「フォービドゥンフルーツ」を使わずにこの特技を使用すると「虚無召来」の効果が発生する。",
-        "Uses up all of your MP (at least 100) and consumes a 'Forbidden Fruit' item; fires an extremely powerful irresistable ball attack. Using this special ability without 'Forbidden Fruit' activates the effect of 'Call the Void'.")},
+        "Uses up all of your MP (at least 100) and consumes a 'Forbidden Fruit' item; fires an extremely powerful irresistible ball attack. Using this special ability without 'Forbidden Fruit' activates the effect of 'Call the Void'.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",""},
 };
@@ -29677,7 +29677,7 @@ cptr do_cmd_class_power_aux_flan(int num, bool only_info)
 			int base = plev + adj_general[p_ptr->stat_ind[A_CHR]] * 5;
 			if (only_info) return format(_("損傷:%d+1d%d", "dam: %d+1d%d"), base, base);
 
-			msg_print(_("あなたの魔力が檻のように部屋を埋め尽くした！", "Your magical power fills the room in form of a cage!"));
+			msg_print(_("あなたの魔力が檻のように部屋を埋め尽くした！", "Your magical power fills the room in the form of a cage!"));
 			project_hack2(GF_MISSILE, 1, base, base);
 			project_hack(GF_NO_MOVE, base / 20);
 
@@ -29693,7 +29693,7 @@ cptr do_cmd_class_power_aux_flan(int num, bool only_info)
 			if(use_itemcard) dam = 500 + plev*20;
 
 			if(only_info) return format(_("損傷:最大%d", "dam: up to %d"),dam/2);
-			msg_print(_("災厄の炎が周囲を焼き払った！", "Calamitious flames scorch the area!"));
+			msg_print(_("災厄の炎が周囲を焼き払った！", "Calamitous flames scorch the area!"));
 			project(0, rad, py, px, dam, GF_HELL_FIRE, PROJECT_KILL | PROJECT_ITEM, -1);
 			break;
 		}
@@ -29868,10 +29868,10 @@ class_power_type class_power_mystia[] =
         "Stops singing the song you're singing right now. Doesn't consume energy.")},
 	{3,3,20,FALSE,TRUE,A_CHR,0,0,_("梟の夜鳴声", "Hooting in the Night"),
 		_("あなたが今いる部屋を暗くする。",
-        "Darkness nearby area.")},
+        "Darkens nearby area.")},
 	{5,8,30,FALSE,TRUE,A_CHR,0,0,_("夜雀の歌", "Song of the Night Sparrow"),
 		_("周囲のモンスターを鳥目にする歌を歌う。歌っている間はMPを消費し続ける。鳥目になった敵は高確率であなたの位置を見失い無防備にあなたの攻撃を受けるが、部屋が明るかったり敵が視覚に頼らない存在だと効果が薄い。",
-        "Sings a song that makes nearby monsters night-blind. Singing continuously consumes MP. Night-blind enemies have high chance of losing sight of you, becoming defenseles before your attack. Less effective in illuminated areas or against enemies not relying on vision.")},
+        "Sings a song that makes nearby monsters night-blind. Singing continuously consumes MP. Night-blind enemies have high chance of losing sight of you, becoming defenseless before your attacks. Less effective in illuminated areas or against enemies not relying on vision.")},
 	{10,10,30,FALSE,TRUE,A_DEX,0,0,_("毒蛾の鱗粉", "Poisonous Moth's Scales"),
 		_("周辺の敵を混乱させる。",
         "Confuses nearby enemies.")},
@@ -29889,7 +29889,7 @@ class_power_type class_power_mystia[] =
         "Sings a song that stops movement of nearby humans. Also, gives a human slayer effect to your attacks. Singing continuously consumes MP.")},
 	{40,36,75,FALSE,TRUE,A_CHR,0,0,_("真夜中のコーラスマスター", "Midnight Chorus Master"),
 		_("周囲の敵を魅了・攻撃力低下状態にする歌を歌う。歌っている間はMPを消費し続ける。",
-        "Sings a song that charms and lower attack power of nearby enemies into being your followers. Singing continuously consumes MP.")},
+        "Sings a song that lowers attack power of nearby enemies and charms them into being your followers. Singing continuously consumes MP.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",
 		""},
@@ -30031,7 +30031,7 @@ class_power_type class_power_banki[] =
         "Makes two of your nearby head clones disappear and fires a powerful non-elemental beam. This attack doesn't deal damage to your other heads.")},
 	{ 38,88,70,FALSE,TRUE,A_CHR,0,0,_("デュラハンナイト", "Dullahan Night"),
 		_("視界内全てに対し「死の光線」属性の攻撃を複数回行う。攻撃回数は視界内のあなたの首の数によって増える。",
-        "Hits everyone in sight with multiple death ray attacks. Amount of attacks increases depending on amount of your heads in sight.")},
+        "Hits everyone in sight with multiple death ray attacks. Number of attacks increases depending on amount of your heads in sight.")},
 
 	{ 44,60,75,FALSE,TRUE,A_DEX,0,0,_("ヘルズレイ", "Hell's Ray"),
 		_("指定したターゲット周辺に向けて無属性のビームを数発放つ。頭の分身がいてそのターゲットに視線が通っている場合頭の分身からも同じようにビームを放つ。この攻撃であなたと分身がダメージを受けることはない。",
@@ -30421,7 +30421,7 @@ class_power_type class_power_librarian[] =
 {
 	{40,0,50,FALSE,TRUE,A_DEX,0,0,_("高速詠唱", "High-Speed Casting"),
 		_("素早く魔法を詠唱する。ただし消費MPが30%増加し、魔法詠唱成功後にキャンセルしても行動順を消費する。",
-        "Casts a spell, consuming less energy than unusual. However, MP cost is increased by 30%, and energy is consumed even if you cancel casting a spell.")},
+        "Casts a spell, consuming less energy than usual. However, MP cost is increased by 30%, and energy is consumed even if you cancel casting a spell.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",
 		""},
@@ -30493,7 +30493,7 @@ class_power_type class_power_patchouli[] =
         "Generates a ball of sound centered on yourself, and hits everything in sight with nuclear heat.")},
 	{ 48,96,80,FALSE,TRUE,A_INT,0,0,_("賢者の石", "Philosopher Stone"),
 		_("強力な元素攻撃を行う「賢者の石」を配下として召喚する。階移動すると消える。",
-        "Summons a Philosopher Stone which uses powerful elemental attacks as your follower. Disappear if you move to another level.")},
+        "Summons a Philosopher's Stone which uses powerful elemental attacks as your follower. Disappears if you move to another level.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",""},
 };
@@ -30660,7 +30660,7 @@ cptr do_cmd_class_power_aux_patchouli(int num, bool only_info)
 			}
 
 			if(summon_named_creature(0, py, px, MON_PHILOSOPHER_STONE, PM_EPHEMERA)) msg_print(_("賢者の石を呼び出した！",
-                                                                                                "You call forth a Philosopher Stone!"));
+                                                                                                "You call forth a Philosopher's Stone!"));
 			else msg_print(_("魔法に失敗した。", "Your spell failed."));
 
 		break;
@@ -31026,16 +31026,16 @@ class_power_type class_power_magic_knight_elem[] =
 {
 	{8,16,30,FALSE,TRUE,A_INT,0,0,_("炎の魔法剣", "Magic Sword (Fire)"),
 		_("短時間の間、火炎属性で攻撃できるようになる。",
-        "For a short period of time, makes you currently wielde weapon attack with fire.")},
+        "For a short period of time, makes you currently wielded weapon attack with fire.")},
 	{16,16,30,FALSE,TRUE,A_INT,0,0,_("氷の魔法剣", "Magic Sword (Frost)"),
 		_("短時間の間、冷気属性で攻撃できるようになる。",
-        "For a short period of time, makes you currently wielde weapon attack with cold.")},
+        "For a short period of time, makes you currently wielded weapon attack with cold.")},
 	{24,16,30,FALSE,TRUE,A_INT,0,0,_("雷の魔法剣", "Magic Sword (Lightning)"),
 		_("短時間の間、電撃属性で攻撃できるようになる。",
-        "For a short period of time, makes you currently wielde weapon attack with lightning.")},
+        "For a short period of time, makes you currently wielded weapon attack with lightning.")},
 	{32,16,30,FALSE,TRUE,A_INT,0,0,_("酸の魔法剣", "Magic Sword (Acid)"),
 		_("短時間の間、酸属性で攻撃できるようになる。",
-        "For a short period of time, makes you currently wielde weapon attack with acid.")},
+        "For a short period of time, makes you currently wielded weapon attack with acid.")},
 
 	{99,0,0,FALSE,FALSE,0,0,0,"dummy",
 		""},
@@ -31778,7 +31778,7 @@ class_power_type class_power_shinmyoumaru[] =
         "Fully recovers HP, restores experience and stat drain and removes negative effects. The price is either memory loss (50%) or equipment disenchantment (20%).")},
 	{37,37,0,FALSE,FALSE,A_WIS,0,0,_("この階全部見えろ！", "Make Me See the Entire Level!"),
 		_("マップを明るく照らし、全ての地形・アイテム・トラップ・モンスターを感知する。代償として＜幻覚(30%)・経験値大幅一時減少(20%)・ダンジョンの壁が消えてモンスターが起きる(10%)＞のいずれかが起こることがある。",
-        "Lights up the entire map, reveals the layout and detects items, traps and monsters. The price is either halluciantion (30%), great experience drain (20%) or dungeon walls disappearing and monsters waking up (10%).")},
+        "Lights up the entire map, reveals the layout and detects items, traps and monsters. The price is either hallucination (30%), great experience drain (20%) or dungeon walls disappearing and monsters waking up (10%).")},
 	{40,75,80,FALSE,TRUE,A_WIS,0,0,_("輝針剣", "Shining Needle Sword"),
 		_("ターゲット周辺に向けて防御不可能なビーム攻撃を連続で放つ。",
         "Fires multiple unblockable beams at the area near the target.")},
@@ -31899,7 +31899,7 @@ void koduchi_payment(int kind)
 		break;
 	case 17: //エキサイトモンスター
 		msg_print(_("恐ろしい音がダンジョンに鳴り響いた！",
-                    "A terrifying sound echose through the dungeon!"));
+                    "A terrifying sound echoes through the dungeon!"));
 		aggravate_monsters(0,TRUE);
 		break;
 
@@ -32314,7 +32314,7 @@ cptr do_cmd_class_power_aux_shinmyoumaru(int num, bool only_info)
 			if(only_info) return format(_("充填:%dターン", "chrg: %d turns"),charge);
 
 			msg_print(_("小槌を振ると千里先をも見通せるようになった！",
-                        "As you swing the mallet, you feel like you can see for thousands miles!"));
+                        "As you swing the mallet, you feel like you can see for thousands of miles!"));
 
 			wiz_lite(FALSE);
 			(void)detect_traps(255, TRUE);
@@ -32340,7 +32340,7 @@ cptr do_cmd_class_power_aux_shinmyoumaru(int num, bool only_info)
 			if(only_info) return format(_("損傷:(%dd%d) * %d", "dam: (%dd%d) * %d"),dice,sides,num);
 
 			if (!get_aim_dir(&dir)) return NULL;
-			msg_format(_("眩く輝く%s刃を放った！", "You throw %sdazzlingly shining blades!"),(p_ptr->mimic_form==MIMIC_GIGANTIC)?
+			msg_format(_("眩く輝く%s刃を放った！", "You throw %s dazzlingly shining blades!"),(p_ptr->mimic_form==MIMIC_GIGANTIC)?
                                                                                                 _("巨大な", "giant, "):"");
 			fire_blast(GF_PSY_SPEAR, dir, dice, sides, num, 2,(PROJECT_BEAM | PROJECT_KILL | PROJECT_GRID | PROJECT_ITEM));
 
@@ -33523,7 +33523,7 @@ cptr do_cmd_class_power_aux_koishi(int num, bool only_info)
 	{
 		base = plev + adj_general[p_ptr->stat_ind[A_CHR]] * 5;
 		if (only_info) return format(_("効力:%d+1d%d", "pow: %d+1d%d"), base, base);
-		msg_format(_("強烈な抑圧が発動された！", "You cause intense supression!"));
+		msg_format(_("強烈な抑圧が発動された！", "You cause intense suppression!"));
 
 		//v1.1.95
 		project_hack2(GF_SUPER_EGO, 1, base, base);
@@ -34367,7 +34367,7 @@ class_power_type class_power_kasen[] =
         "Breathes sound. Power is equal to 1/3 of current HP.")},
 	{45,70,75,FALSE,TRUE,A_INT,0,0,_("方術", "Fangshi"),
 		_("空間操作の術を使い、周囲の敵が自分を見失いやすくなる。",
-        "Performs a spatial manipulation technique, making it harder for neabry enemies to notice you.")},
+        "Performs a spatial manipulation technique, making it harder for nearby enemies to notice you.")},
 
 
 
@@ -34676,7 +34676,7 @@ cptr do_cmd_class_power_aux_kogasa(int num, bool only_info)
 			base = p_ptr->lev * 4 + chr_adj * 7;
 
 			if (only_info) return format(_str_eff_dam_around, base / 2);
-			msg_format(_("あなたは水弾をばら撒いた。", "You scatter water bullets arounds."));
+			msg_format(_("あなたは水弾をばら撒いた。", "You scatter water bullets around."));
 			project(0, rad, py, px, base, GF_WATER, PROJECT_KILL | PROJECT_ITEM, -1);
 			break;
 		}
@@ -34839,7 +34839,7 @@ class_power_type class_power_komachi[] =
         "Has low chance of defeating an adjacent enemy in single strike, and medium chance of halving their HP. Effects only living beings and does nothing if resisted. Requires wielding a scythe.")},
 	{38,44,70,FALSE,TRUE,A_WIS,0,0,_("死者選別の鎌", "Scythe that Chooses the Dead"),
 		_("敵の頭上から光の刃を落とす。アンデッドの場合4倍のダメージを与えて高確率で一撃で倒す。鎌を装備していないと使えない。",
-        "Drop a blade of light on top of an enemy. Deals quadraple damage to undead and has a high chance of defeating them in a single strike. Requires wielding a scythe.")},
+        "Drop a blade of light on top of an enemy. Deals quadruple damage to undead and has a high chance of defeating them in a single strike. Requires wielding a scythe.")},
 
 	{40,50,80,FALSE,FALSE,A_DEX,0,0,_("距離を操るⅡ", "Manipulation of Distance II"),
 		_("一グリッド分の壁や扉をすり抜ける。抜けた先にモンスターがいる場合失敗する。テレポート不可地形の中にも入れる。",
@@ -35292,7 +35292,7 @@ cptr do_cmd_class_power_aux_iku(int num, bool only_info)
 	case 1:
 		{
 			if(only_info) return format(_("期間:20+1d20", "dur: 20+1d20"));
-			msg_format(_("トゲのようなオーラをまとった。", "You don an thorn-like aura."));
+			msg_format(_("トゲのようなオーラをまとった。", "You don a thorn-like aura."));
 			  set_dustrobe(20+randint1(20),FALSE);
 			break;
 		}
@@ -35502,7 +35502,7 @@ cptr do_cmd_class_power_aux_udonge(int num, bool only_info)
 			if(only_info) return "";
 
 			msg_format(_("周囲の存在から放たれる波長を読み取った。",
-                        "You read wavelengthes emitted by nearby beings."));
+                        "You read wavelengths emitted by nearby beings."));
 			probing();
 			break;
 		}
@@ -36238,7 +36238,7 @@ class_power_type class_power_maid[] =
         "Returns from depths of dungeons by any means necessary.")},
 	{	40,1,70,FALSE,FALSE,A_CHR,0,0,_("ティータイム", "Teatime"),
 		_("リラックスしてMPを回復する。お茶菓子として菓子を消費する。",
-        "Relax and recover MP. Uses sweets as tea conficteonery.")},
+        "Relax and recover MP. Uses sweets as tea confectionery.")},
 
 	{	99,0,0,FALSE,FALSE,0,0,0,"dummy",	""	},
 };
@@ -36488,7 +36488,7 @@ bool check_class_skill_usable(char *errmsg,int skillnum, class_power_type *class
 #ifdef JP
 				my_strcpy(errmsg, "その奇跡を起こすには神奈子様に捧げる詠唱が足りない。", 150);
 #else
-                my_strcpy(errmsg, "You haven't perform enough prayers to Lady Kanako to cause this miracle.", 150);
+                my_strcpy(errmsg, "You haven't performed enough prayers to Lady Kanako to cause this miracle.", 150);
 #endif
 				return FALSE;
 			}
@@ -36508,7 +36508,7 @@ bool check_class_skill_usable(char *errmsg,int skillnum, class_power_type *class
 #ifdef JP
 				my_strcpy(errmsg, "その奇跡を起こすには諏訪子様に捧げる詠唱が足りない。", 150);
 #else
-                my_strcpy(errmsg, "You haven't perform enough prayers to Lady Suwako to cause this miracle.", 150);
+                my_strcpy(errmsg, "You haven't performed enough prayers to Lady Suwako to cause this miracle.", 150);
 #endif
 				return FALSE;
 			}
@@ -37209,7 +37209,7 @@ bool check_class_skill_usable(char *errmsg,int skillnum, class_power_type *class
 #ifdef JP
 				my_strcpy(errmsg, "ここでは落ち着いて眠れない。", 150);
 #else
-                my_strcpy(errmsg, "You can't peacefully slep here.", 150);
+                my_strcpy(errmsg, "You can't peacefully sleep here.", 150);
 #endif
 				return FALSE;
 			}

--- a/src/tables.c
+++ b/src/tables.c
@@ -2628,10 +2628,10 @@ const player_class class_info[MAX_CLASS] =
 #ifdef JP
 		"守護者",
 		"守護者",
-		"Protector",
+		"Guardian",
 #else
-		"Protector",
-		"Protector",
+		"Guardian",
+		"Guardian",
 #endif
 		{ 1, -2, 2, -1, 2, 3},
 		16, 20, 37, 1, 18, 35, 68, 40,
@@ -10427,7 +10427,7 @@ const option_type option_info[] =
 	{ &left_hander,                 FALSE, OPT_PAGE_BIRTH, 6, 15,
 	"left_hander",                  "左利きである" },
 #else
-	{ &left_hander,                 FALSE, OPT_PAGE_BIRTH, 6, 13,
+	{ &left_hander,                 FALSE, OPT_PAGE_BIRTH, 6, 15,
 	"left_hander",                  "Left-Hander" },
 #endif
 #ifdef JP
@@ -10638,7 +10638,7 @@ const option_type option_info[] =
 	{ &record_arena,                TRUE,  OPT_PAGE_PLAYRECORD, 4, 24,
 	"record_arena",                 "夢日記での勝敗を記録する" },
 #else
-	{ &record_arena,                TRUE,  OPT_PAGE_PLAYRECORD, 4, 21,
+	{ &record_arena,                TRUE,  OPT_PAGE_PLAYRECORD, 4, 24,
 	"record_arena",                 "Record arena victories" },
 #endif
 
@@ -13409,7 +13409,7 @@ const activation_type activation_info[] =
 	{ "SCARE_AREA", ACT_SCARE_AREA, 20, 2500, {20, 0},
 	  _("モンスター恐慌", "frighten monsters") },
 	{ "AGGRAVATE", ACT_AGGRAVATE, 0, 100, {0, 0},
-	  _("モンスターを怒らせる", "aggravete monsters") },
+	  _("モンスターを怒らせる", "aggravate monsters") },
 
 	{ "CHARM_ANIMAL", ACT_CHARM_ANIMAL, 40, 7500, {200, 0},
 	  _("動物魅了", "charm animal") },
@@ -13439,7 +13439,7 @@ const activation_type activation_info[] =
 	  _("蛸の大群召喚", "summon octopus") },
 
 	{ "CHOIR_SINGS", ACT_CHOIR_SINGS, 60, 20000, {300, 0},
-	  _("回復(777)、癒し、士気高揚", "heal 777 hit points, curing and heloism") },
+	  _("回復(777)、癒し、士気高揚", "heal 777 hit points, curing and heroism") },
 	{ "CURE_LW", ACT_CURE_LW, 10, 500, {10, 0},
 	  _("恐怖除去/体力回復(30)", "remove fear and heal 30 hp") },
 	{ "CURE_MW", ACT_CURE_MW, 20, 750, {3, 3},
@@ -13634,7 +13634,7 @@ const activation_type activation_info[] =
 	  _("遅鈍のボルト(4d6)", "bolt of inertia (4d6)") },
 
 	  { "MATARA", ACT_MATARA, 50, 10000, {100, 0},
-	  _("鼓を鳴らす", "ring the drum") },
+	  _("鼓を鳴らす", "play the drum") },
 	  { "HYAKKIYAKOU", ACT_HYAKKIYAKOU, 30, 10000, {10, 10},
 	  _("百鬼夜行", "hundred oni night parade") },
 
@@ -14149,7 +14149,7 @@ cptr alice_doll_name[INVEN_DOLL_NUM_MAX] =
 	_("蓬莱人形", "Hourai Doll"),
 	_("露西亜人形", "Russian Doll"),
 	_("倫敦人形", "London Doll"),
-	_("オルレアン人形", "Orlean Doll"),
+	_("オルレアン人形", "Orleans Doll"),
 	_("京人形", "Kyoto Doll"),
 	_("ゴリアテ人形", "Goliath Doll"),
 };
@@ -14200,7 +14200,7 @@ struct marisa_magic_type marisa_magic_table[MARISA_MAX_MAGIC_KIND] =
 	{0,0,0,10,0,0,0,0},FALSE},
 	{_("エスケープベロシティ", "Escape Velocity"),
 	_("隣接した敵全てに魔力属性攻撃を行い、\\その後一瞬で短距離のテレポートを行う。",
-    "Deals mana damage to all adjacent enemies, \\then immediately teleports aways a short distance."),
+    "Deals mana damage to all adjacent enemies, \\then teleports away a short distance."),
 	{0,0,5,0,0,10,0,0},FALSE},
 
 	{_("コールドインフェルノ", "Cold Inferno"),
@@ -14243,7 +14243,7 @@ struct marisa_magic_type marisa_magic_table[MARISA_MAX_MAGIC_KIND] =
 	{0,0,0,20,20,20,0,20},TRUE},
 	{_("強化丹", "Enhanced Elixir"),
 	_("体力を最大値まで回復し全てのステータス異常を治癒する薬を作る。",
-    "Creates a potion that fully recovers HP and curess all status abnormalities."),
+    "Creates a potion that fully recovers HP and cures all status abnormalities."),
 	{0,50,0,50,0,0,0,20},TRUE},
 	{_("スターダストレヴァリエ", "Stardust Reverie"),
 	_("自分の周囲に強力な閃光属性のボールを連続で発生させる。",
@@ -15313,7 +15313,7 @@ soldier_skill_type soldier_skill_table[SOLDIER_SKILL_ARRAY_MAX][SOLDIER_SKILL_NU
 		{0,_("近接射撃技術", "Close-Range Shooting"),
             _("モンスターに至近距離で射撃したときクリティカルヒットが発生しやすくなる。",
             "Increases critical hit chance when shooting monsters at close range.")},
-		{0,_("一撃離脱戦法", "Hit and Away Tacttics"),
+		{0,_("一撃離脱戦法", "Hit and Away Tactics"),
             _("隣接攻撃のあと一瞬で離脱する特技「ヒット＆アウェイ」を使用可能になる。",
             "Lets you use the 'Hit and Away' special ability.")},
 		{0,_("戦地調達", "Battlefield Preparations"),
@@ -15343,7 +15343,7 @@ soldier_skill_type soldier_skill_table[SOLDIER_SKILL_ARRAY_MAX][SOLDIER_SKILL_NU
             "Increases searching skill. \\At level 10, lets you use the 'Survey Surroundings' special ability.")},
 		{0,_("障害物製作技術", "Create Obstacles"),
             _("隣接した床一か所を岩石地形にする「バリケード設置」を使用可能になる。",
-            "Lets you use the 'Set Up Barricade' special ability that creates rubbles on an adjacent open floor.")},
+            "Lets you use the 'Set Up Barricade' special ability that creates rubble on an adjacent open floor.")},
 		{0,_("ポータル設置", "Set Up Portal"),
             _("フロアの床に二箇所までポータル地形を設置でき、ポータル間を移動できる。\\テレポート妨害の効果を受けない。\\三箇所目以降を設置しようとすると古いポータルから順に消える。",
             "Sets up to 2 portals on open floor that you can move between. \\Ignores teleportation prevention. \\Placing a third portal will remove your first.")},
@@ -15389,7 +15389,7 @@ soldier_skill_type soldier_skill_table[SOLDIER_SKILL_ARRAY_MAX][SOLDIER_SKILL_NU
             "Lets you use the 'Create Ammo' special ability to turn materials into ammo. \\This ammo can be used with 'Switch Ammo' to perform powerful shooting attacks.")},
 		{40,_("ナイトビジョン", "Night Vision"),
             _("暗闇でも物が見られるようになる。\\暗闇で近接攻撃や銃による射撃を行ったときクリティカルヒット率が上昇する。\\視界に頼らないモンスターには効果が薄い。",
-            "Makes you able to see in the dark. \\Increases critical hit chance for melee and shooting attacks while in darkness. \\Less effectvie against monsters not relying on sight.")},
+            "Makes you able to see in the dark. \\Increases critical hit chance for melee and shooting attacks while in darkness. \\Less effective against monsters not relying on sight.")},
 		{45,_("魔弾の射手", "Freischutz"),
             _("射撃成功率と全ての射撃のクリティカルヒット判定値が大幅に増加する。\\またアーティファクト発動「魔弾の射手」が精神集中と周囲の敵の数に応じて強化される。",
             "Greatly raises shooting attack success rate and critical hit chance. \\Also, the 'Freischutz' artifact activation will increase in power based on your concentration state and amount of enemies nearby.")},
@@ -15444,22 +15444,22 @@ soldier_bullet_type soldier_bullet_table[] =
 	{0,_("ダミー","dummy"),"",0},
 	//31-48宝石弾
 	{0,_("猛毒弾","toxic bullet"),_("威力3倍の毒属性になる。","3x damage from poison"),SS_M_MATERIAL_BULLET},
-	{0,_("獣殺しの弾丸","animal slayer"),_("獣に対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage to animals; increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("磁力弾","magnetic bullet"),_("無生物に対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage to nonliving; increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("破魔の弾丸","demon slayer"),_("妖怪・アンデッド・デーモンに対して威力が2倍になる。\\ボルトでも反射されない。","2x damage against youkai, undead, and demons; even shots not refected"),SS_M_MATERIAL_BULLET},
-	{0,_("怨霊の弾丸","widow maker"),_("人間に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage to humans; greatly increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("太陽の弾丸","bird shot"),_("飛行するモンスターに対して威力が2倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","2x damage to flying monsters; increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("銀の弾丸","silver bullet"),_("混沌の勢力に威力1.5倍、\\妖怪・アンデッド・デーモンに対して威力が3倍になる。\\クリティカルヒット率が上昇する。\\ボルトでも反射されない。","1.5x damage to chaotic forces; 3x damage against youkai, undead, and domes; increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("重量弾","heavy ammunition"),_("威力2倍の通常の射撃になる。\\クリティカルヒット率が上昇する。反射されない。","2x damage; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("獣殺しの弾丸","animal slayer"),_("獣に対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage to animals; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("磁力弾","magnetic bullet"),_("無生物に対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage to nonliving; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("破魔の弾丸","demon slayer"),_("妖怪・アンデッド・デーモンに対して威力が2倍になる。\\ボルトでも反射されない。","2x damage against youkai, undead, and demons; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("怨霊の弾丸","widow maker"),_("人間に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage to humans; greatly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("太陽の弾丸","bird shot"),_("飛行するモンスターに対して威力が2倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","2x damage to flying monsters; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("銀の弾丸","silver bullet"),_("混沌の勢力に威力1.5倍、\\妖怪・アンデッド・デーモンに対して威力が3倍になる。\\クリティカルヒット率が上昇する。\\ボルトでも反射されない。","1.5x damage to chaotic forces; 3x damage against youkai, undead, and demons; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("重量弾","heavy bullet"),_("威力2倍の通常の射撃になる。\\クリティカルヒット率が上昇する。反射されない。","2x damage; increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
 	{0,_("ドラゴンブレス弾","dragon's breath bullet"),_("3倍の威力のブレスになる。","3x damage; acts like breath weapon"),SS_M_MATERIAL_BULLET},
 	{0,_("水龍の弾丸","water dragon bullet"),_("威力3倍の極寒属性ロケットになる。","a frigid rocket with 3x damage"),SS_M_MATERIAL_BULLET},
-	{0,_("竜殺しの弾丸","dragon slayer"),_("竜に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage against dragons; greatly increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("神殺しの弾丸","god slayer"),_("神格に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage against deities; greatly increased criticals; even shots not reflected"),SS_M_MATERIAL_BULLET},
-	{0,_("悪夢の弾丸","nightmare bullet"),_("地獄の業火弱点のモンスターに対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage against holy monsters; greatly increased criticals; event shots not reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("竜殺しの弾丸","dragon slayer"),_("竜に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage against dragons; greatly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("神殺しの弾丸","god slayer"),_("神格に対して威力が3倍になりクリティカルヒット率が大幅に上昇する。\\ボルトでも反射されない。","3x damage against deities; greatly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("悪夢の弾丸","nightmare bullet"),_("地獄の業火弱点のモンスターに対して威力が3倍になりクリティカルヒット率が上昇する。\\ボルトでも反射されない。","3x damage against holy monsters; greatly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
 	{0,_("聖なる弾丸","holy bullet"),_("威力3倍の破邪属性ロケットになる。","radius 2 racket; 3x damage"),SS_M_MATERIAL_BULLET},
 	{0,_("真紅の弾丸","crimson bullet"),_("威力5倍の火炎属性ビームになる。","beam of fire; 5x damage"),SS_M_MATERIAL_BULLET},
-	{0,_("金剛弾","Kongo bullet"),_("威力4倍の光の剣属性のビームになる。","slashing light beam; 4x damage"),SS_M_MATERIAL_BULLET},
-	{0,_("流星弾","meteor"),_("威力4倍の通常射撃になる。\\クリティカルヒット率が大幅に上昇する。反射されない。","4x damage; significantly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
+	{0,_("金剛弾","diamond bullet"),_("威力4倍の光の剣属性のビームになる。","slashing light beam; 4x damage"),SS_M_MATERIAL_BULLET},
+	{0,_("流星弾","meteor bullet"),_("威力4倍の通常射撃になる。\\クリティカルヒット率が大幅に上昇する。反射されない。","4x damage; significantly increased criticals; can't be reflected"),SS_M_MATERIAL_BULLET},
 	{0,_("緋緋色金の弾丸", "scarlet gold bullet"),_("威力10倍の分解属性大型ビームになる。","disintegrating beam; 10x damage"),SS_M_MATERIAL_BULLET},
 
 


### PR DESCRIPTION
- Translations/changes to monsters, ability descriptions, egos.
- Change "Protector" class name to "Guardian" as it's more natural (protector works better as "protector of..."). It could also be "Defender" to match the item ego.
- Fix two broken settings.