### PR TITLE
Speech translation notes, spell names, description changes

### DIFF
--- a/lib/edit/a_info.txt
+++ b/lib/edit/a_info.txt
@@ -4130,7 +4130,7 @@ P:0:1d1:0:0:25
 F:STR | CON
 F:RES_FIRE | RES_COLD | RES_ELEC | RES_POIS | RES_ACID | 
 F:RES_CONF | RES_BLIND | RES_FEAR | FREE_ACT
-D:$This headband embodies the indomitable spirit of the legendary biker boss.
+D:$This headband embodies the indomitable spirit of a legendary biker boss.
 D:$Inexplicably, they'll sometimes wash up in Gensoukyou in groups.
 D:伝説の総長の不屈の闘志が込められたハチマキだ。
 D:なぜか時々数本まとめて幻想郷に流れ着く。
@@ -5252,7 +5252,7 @@ W:25:50:30:80000
 P:0:3d4:18:18:0
 F:STR | DEX | CON | CHR | SPEED | RES_POIS | RES_FEAR | FREE_ACT
 F:KILL_KWAI | SLAY_KWAI | SLAY_HUMAN | VORPAL | BLESSED | SUST_STR
-D:$A sword of great reknown that has been called many different names by the Seiwa Genji clan.
+D:$A sword of great renown that has been called many different names by the Seiwa Genji clan.
 D:$It was originally called 'Hizakirimaru'.                                              
 D:$When Yorimitsu used it to slay a tsuchigumo, he named it 'Kumokirimaru'.                                               
 D:$When Tameyoshi heard it sound like a snake in the night, he named it 'Hoemaru'.                                           
@@ -5470,7 +5470,7 @@ P:0:4d8:20:20:0
 F:STR | WIS | VORPAL | SHOW_MODS | SLAY_UNDEAD | SLAY_ANIMAL
 F:FREE_ACT | INFRA | RES_FEAR | RES_CONF | RES_CHAOS | QUESTITEM
 F:ACTIVATE | LITE | WARNING
-D:$The sculptor god Haniyasukami-uchigi-hime created this sword specially for the commander of the Haniwa Army Corps.
+D:$The sculptor god Keiki Haniyasushin created this sword specially for the commander of the Haniwa Army Corps.
 D:造形神『埴安神 袿姫』が埴輪兵団の兵長のために創り出した特別製の剣だ。
 U:SUMMON_HANIWA
 
@@ -5485,7 +5485,7 @@ F:INT | DEX | CHR | DISARM
 F:RES_ACID | RES_ELEC | RES_FIRE | RES_COLD | RES_POIS | RES_WATER | RES_NETHER
 F:ACTIVATE | QUESTITEM
 U:ULTIMATE_RESIST
-D:$An apron hand-made by the sculptor god Haniyasukami-uchigi-hime.
+D:$An apron hand-made by the sculptor god Keiki Haniyasushin.
 D:$It's woven with special ceramic fibers. Mundane attacks won't even leave a scratch.
 D:造形神『埴安神 袿姫』手製のエプロンだ。
 D:特殊セラミックファイバーが織り込まれており並大抵の攻撃では傷一つつかない。

--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -5874,7 +5874,7 @@ I:75:49:0
 W:20:0:4:30000
 A:20/8:30/4:80/4
 P:0:1d1:0:0:0
-D:$It increases your intellingence when you quaff it.
+D:$It increases your intelligence when you quaff it.
 D:それは飲むと知能の最大値が上がる。
 
 N:569:賢さ:泡だった
@@ -6709,7 +6709,7 @@ D:紅魔館のパーティーでよく出る酒だ。
 
 
 N:649:酒虫(改)の酒
-E:Insect Sake (Revised)
+E:Sake Bug Sake (Revised)
 G:!:y
 I:78:20:7000
 W:0:0:10:15000

--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -7653,7 +7653,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 D:特殊処理用
 
 N:733:ウルトラソニック眠り猫
-E:& Ultrasonic Whistle~
+E:& Ultrasonic Sleeping Cat~
 G:`:u
 I:72:10:0
 W:10:0:50:3000
@@ -8045,7 +8045,7 @@ D:変身中は身体能力と格闘能力が大幅に上昇するが、多くの武器防具が無効化され、
 D:魔法、魔道具、巻物が使えなくなる。
 
 N:772:時空消滅内服液
-E:& Medicine~ of Temporal Disappearnace
+E:& Medicine~ of Temporal Disappearance
 G:!:b
 I:81:12:0
 W:1:0:5:0
@@ -8661,7 +8661,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 D:大きな羊皮紙にくるまれた香木製の箱だ。箱には不気味な彫刻が施されている…
 
 N:830:銀の鍵
-E:Silver key
+E:Silver Key
 G:\:w
 I:72:18:0
 W:25:0:10:100000
@@ -8673,7 +8673,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD | USABLE
 
 
 N:831:オニフスベ:白くて大きな
-E:& Giant puffball~
+E:& Giant Puffball~
 G:,:y
 I:74:32:10000
 W:10:0:20:1
@@ -9016,7 +9016,7 @@ D:不思議な材質の半透明の球だ。中には星のような文様がひとつ浮かび上がっているのが
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 N:864:優曇華の盆栽
-E:udonge
+E:Bonsai Udonge
 G:&:v
 I:82:26:0
 W:1:0:150:70000000
@@ -9360,7 +9360,7 @@ D:$A small box decorated with lots of flair. You can't wait to open it!
 D:やたらと派手に光る小箱だ。これを開けるときには興奮を抑えきれないだろう！
 
 N:897:酔魔の酒の空き瓶
-E:& Empty alcohol bottle~
+E:& Empty Alcohol Bottle~
 G:!:w
 I:72:32:0
 W:25:0:5:10
@@ -9403,7 +9403,7 @@ F:INSTA_ART
 
 
 N:901:ルナティックガン改
-E:Lunatic gun Mk II
+E:Lunatic Gun Mk II
 G:}:w
 I:33:11:0
 W:45:0:30:10000
@@ -9439,7 +9439,7 @@ F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 
 
 N:904:奇妙な豆
-E:Strange bean
+E:Strange Bean
 G:,:g
 I:80:12:5000
 W:65:0:10:10

--- a/lib/edit/r_info.txt
+++ b/lib/edit/r_info.txt
@@ -23558,7 +23558,7 @@ D:$"...a wily-looking little man, with a sharp nose and a
 D:$laughing mouth and a shock of straw-colored hair. He was dressed
 D:$in something like a Renaissance costume of orange, red, and brown.
 D:$He wore long hose and a tight-fitting embroidered doublet."
-D:$(Roger Zelazny, Nine Princes in Amber, p.28)
+D:$(Roger Zelazny, 'Nine Princes in Amber', p.28)
 D:ランダムは九王子の末弟で、あちこちの影を遊び歩いて過ごしていた。
 D:打算的で気分屋だが意外に義理堅いところもある。
 D:「ずるそうな顔つきの小男。尖った鼻、笑っている口、むぎわらを束ねたような髪。
@@ -24162,9 +24162,9 @@ F:NO_CONF | NO_SLEEP | CAN_FLY |
 F:BASH_DOOR | POWERFUL |
 S:1_IN_5 |
 S:BR_SHAR |
-D:$"And this beauty! What radiance! More wonderful than anything I've ever seen!" 
+D:$"And this beauty! What radiance! More wonderful than anything I've ever seen!"  
 D:$"Finally... finally, I have conquered the sun!"
-D:$(Hirohiko Araki, Jojo's Bizarre Adventure, Vol. 12)
+D:$(Hirohiko Araki, 'Jojo's Bizarre Adventure', Vol. 12)
 D:「そして　あの！美しい！なんという輝き！今まで見た何よりもすばらしい…」
 D:「あの太陽をついに…ついに…克服したぞ！」
 D:(荒木飛呂彦　ジョジョの奇妙な冒険 12巻)
@@ -24184,7 +24184,7 @@ F:SMART | OPEN_DOOR |
 F:NO_CONF | NO_SLEEP | NO_FEAR
 S:1_IN_5 | 
 S:HEAL | PUNISH_3 |
-D:$"Repent, ye dead! Discover faith in death!" (Kentaro Miura, Berserk, volume 20)
+D:$"Repent, ye dead! Discover faith in death!" (Kentaro Miura, 'Berserk', volume 20)
 D:「悔い改めよ亡者ども！信仰とは死ぬことと見つけたり！」　　(三浦建太郎　「ベルセルク」 20巻)
 
 #1202を倒すまでは通常出現しない
@@ -24205,7 +24205,7 @@ F:NO_CONF | NO_SLEEP | NO_FEAR | NO_STUN
 S:1_IN_4 | 
 S:BR_HOLY | BR_FIRE
 D:$"You fool who does not fear God, God's punishment is swift and certain! 
-D:$I will punish you on behalf of heaven!" (Kentaro Miura, Berserk, volume 21)
+D:$I will punish you on behalf of heaven!" (Kentaro Miura, 'Berserk', volume 21)
 D:「神を畏れぬ愚か者よ　天罰覿面！　天に代わりてこの私が！あなたにバチを当てましょう！」
 D:　　(三浦建太郎　「ベルセルク」 20巻)
 
@@ -26321,7 +26321,7 @@ F:OPEN_DOOR | BASH_DOOR | GEN_HUMAN | HANIWA | FRIENDS | COLD_BLOOD
 F:NO_CONF | NO_FEAR | NO_SLEEP | REGENERATE
 F:EMPTY_MIND | NONLIVING | STAY_AT_HOME1
 F:IM_FIRE | IM_COLD | IM_ELEC | IM_POIS | RES_WATE | RES_HOLY | RES_NETH | HURT_ROCK
-D:$A Haniwa wielding a sword, created from clay by the sculpting god Haniyasukami-uchigi-hime.
+D:$A Haniwa wielding a sword, created from clay by the sculptor god Keiki Haniyasushin.
 D:造形神『埴安神　袿姫』により生み出された、剣を持つ埴輪だ。
 
 
@@ -26340,7 +26340,7 @@ F:EMPTY_MIND | NONLIVING | STAY_AT_HOME1
 F:IM_FIRE | IM_COLD | IM_ELEC | IM_POIS | RES_WATE | RES_HOLY | RES_NETH | HURT_ROCK
 S:1_IN_2
 S:SHOOT
-D:$A Haniwa wielding a bow, created from clay by the sculpting god Haniyasukami-uchigi-hime.
+D:$A Haniwa wielding a bow, created from clay by the sculptor god Keiki Haniyasushin.
 D:造形神『埴安神　袿姫』により生み出された、弓を持つ埴輪だ。
 
 N:1334:騎馬兵埴輪
@@ -26359,7 +26359,7 @@ F:EMPTY_MIND | NONLIVING | STAY_AT_HOME1
 F:IM_FIRE | IM_COLD | IM_ELEC | IM_POIS | RES_WATE | RES_HOLY | RES_NETH | HURT_ROCK
 S:1_IN_4
 S:SHOOT
-D:$A Haniwa horseman riding a Haniwa horse, created from clay by the sculpting god Haniyasukami-uchigi-hime.
+D:$A Haniwa horseman riding a Haniwa horse, created from clay by the sculptor god Keiki Haniyasushin.
 D:造形神『埴安神　袿姫』により生み出された、埴輪の馬に乗った埴輪の騎兵だ。
 
 N:1335:熟練剣士埴輪

--- a/lib/file/mondeath_gen_e.txt
+++ b/lib/file/mondeath_gen_e.txt
@@ -1,4 +1,5 @@
 #mondeath for Gensoukyou uniques
+#Some translations are sourced from community contributions to touhouwiki.net and thpatch.net
 
 N:1091:Meiling
 # 「済みません、お嬢様～」

--- a/lib/file/mondeath_gen_e.txt
+++ b/lib/file/mondeath_gen_e.txt
@@ -1,301 +1,426 @@
 #mondeath for Gensoukyou uniques
 
 N:1091:Meiling
+# 「済みません、お嬢様～」
 says, 'I'm so sorry, Mistress!'
 
 N:1092:Patchouli
+# 「むきゅー。」
 says, 'Mukyuu.'
+# 「むぎゅー」
 says, 'Mukyuu'
 
 N:1093:Sakuya
+# 「あら、私が先に異変を解決したかったのに」
 says, 'Ah, I wanted to be the one to resolve the incident.'
 
 N:1094:Remilia
+# 「あんたは次の機会に倒してやる」
 says, 'I'll beat you next time.'
 
 N:1095:Flandre
+# 「嘘みたい。私が負けるなんて・・・」
 says, 'This can't be real. I can't believe it...'
 
 N:1096:Letty
+# 「しくしく～」
 says, 'Boo-hoo~'
 
 N:1102:Youmu
+# 「理不尽なー」
 says, 'Outrageous!'
 
 N:1103:Yuyuko
+# 「おやすみ～」
 says, 'Good night~'
 
 N:1107:Mystia
+# 「傷ついた翼にまわる～……って、あ、あれー……」
 sings, 'Circling on my injured wings~... eh, ah, aah-'
+# 「はらほろてぃあ～」
 says, 'Harahorotia~'
+# 「屋根まで飛んで壊れて消えたー♪」
 sings, 'It flew to the roof, broke and disappeared~'
 
 N:1108:Keine
+# 「満月さえあればこんな奴には……」
 says, 'If only it had been a full moon, I could've...'
 
 N:1110:Udongein
+# 「なんていうこと。思ってたよりずっと強い……」
 says, 'Goodness. You're far more than I expected.'
+# 「ああ、師匠にしかられるぅ。」
 says, 'Ah, master will scold me.'
 
 N:1113:Mokou
+# 「なんてこと！もう体力の限界が……」
 says, 'What?! I'm reaching my limit...!'
+# 「痛い痛い、死なないけど痛い～。」
 says, 'Ow, ow! I won't die, but it hurts~'
 
 N:1116:Hina
+# 「私は親切に追い返そうとしただけなのに……」
 says, 'I was just trying to be nice and drive you away...'
 
 N:1117:Nitori
+# 「あーあ、私の光学迷彩スーツが壊れちった」
 says, 'Aww, my optical camouflage suit broke.'
+# 「ううう、負けちった」
 says, 'Uuu, I lose.'
 
 N:1119:Aya
+# 「うーん。隠し撮りしてれば良かったです……」
 says, 'Hmm. I would've been better off taking pictures in secret.'
 
 N:1120:Sanae
+# 「強い……。」
 says, 'Such strength...'
+# 「この幻想郷では常識に囚われてはいけな
 says, 'You can't let yourself be held back by common sense in Gensoukyou.'
 
 N:1122:Suwako
+# 「あーうー。」
 says, 'Auuuuu.'
 
 N:1125:Yamame
+# 「やっぱり強いー捕獲失敗！」
 says, 'You're as tough as expected... a failed capture!'
+# 「しくしく……ひもじいです」
 says, 'Boo-hoo... I'm starving.'
 
 N:1127:Yuugi
+# 「お見事！その腕っ節、気に入ったよ！今日からお前は朋友だ」
 says, 'Well done! I love how strong you are! From now on, we're friends.'
+# 「お見事！その腕っ節、流石にここまで一人で降りてくるだけあるね」
 says, 'Well done! I expected nothing less from someone who made it down here.'
 
 N:1128:Satori
+# 「あらら。こんな地底深くまで降りてくるだけあるわ～」
 says, 'Oh my. Well, you did make it this far underground.'
+# 「人間の心を読み過ぎると気持ち悪くなるのよ」
 mutters, 'Reading human minds too much makes me feel ill.'
 
 N:1129:Rin
+# 「お見事！あたいが負けるとは思わなかったわ」
 exclaims, 'Good job! Wouldn't have thought I'd lose.'
+# 「くー、本当にやるねぇ。あたい、いたく感動したよ！」
 exclaims, 'Wow, you're amazing! I'm so moved!'
 
 N:1130:Utsuho
+# 「って、何をしてたんだっけ？」
 says, 'Wait, what were we doing?'
 
 N:1131:Koishi
+# 「あらららら、負けちゃった」
 says, 'Ohhhh goodness! I lost.'
 
 N:1133:Kogasa
+# 「当って砕けたー」
 says, 'You smashed me up-'
+# 「もう戦いは懲り懲りです」
 says, 'I've had enough, no more, please.'
+# 「ああ、驚いて貰えない妖怪に価値なんて……。」
 says, 'Oh, what's the point of a youkai who can't surprise people?'
 
 N:1134:Ichirin
+# 「悔しいけど……完敗ね。この仇はきっと……」
 says, 'I hate to admit it, but we're utterly beaten. Our foe was too much...'
+# 「あららららー、負けちゃった。」
 says, 'Aww, we lose.'
 
 N:1135:Murasa
+# 「強い……貴方は一体何者？」
 says, 'You're strong... so who are you exactly?'
 
 N:1136:Shou
+# 「負けた……貴方も間違ってはいないというのね」
 says, 'I lose... what you're doing is not wrong either.'
 
 N:1137:Byakuren
+# 「負けちゃった……か。これでは商売あがったりね」
 says, 'I've lost...? This is bad for business.'
 
 N:1139:Kyouko
+# 「やーらーれーたー！」
 yells, 'I'M DONE FOOOOOR!'
 
 N:1140:Yoshika
+# 「うおー！　やーらーれーたー」
 shouts, 'GWAAAAARGH! I'm done fooooor!'
+# 「２２時になったら起こしてね」
 says, 'Wake me up at 10 PM.'
 
 N:1141:Seiga
+# 「あららら、お見事です。流石、幻想郷の人達は腕が立ちますねー」
 says, 'Oh my, how splendid. The people of Gensoukyou truly are talented.'
 
 N:1143:Futo
+# 「こんなにあっさり負けてしまうとは。我はなんの為に千四百年も眠っていたのだろうか」
 says, 'Slept had I fourteen-hundred years only to be defeated utterly?'
+# 「ぐぐ、今回は勝ちを譲ろうぞ」
 says, 'Ugh. On this happening I concede defeat.'
 
 N:1144:Miko
+# 「聞こえるでしょう？　みなが君を称賛する声が」
 says, 'Do you hear that? It's the sound of everyone praising you.'
+# 「本当は私がこの世界の希望になる予定だったけど、ここは君に譲るとしよう」
 says, 'In truth I had planned to become the hope of this world, but I shall concede to you.'
 
 N:1146:Banki
+# 「がっくし。」
 mutters, 'Bah...'
+# 「ぎゃー！」
 yelps, 'Gyah!'
 
 N:1147:Kagerou
+# 「ひー、私のキューティクルが」
 squeals, 'Eek! My cuticle!'
 
 N:1148:Benben
+# 「うーん、まいったまいった。降参よー」
 says, 'Um, I give, I give! I surrender!'
 
 N:1149:Yatsuhashi
+# 「わっほーい。この人、強かったー」
 says, 'Wa-hooi, this person is strong.'
 
 N:1150:Seija
+# 「くう、なんてこった。」
 says, 'What the hell?'
 
 N:1151:Sukuna
+# 「しくしく。この私が敗れるなんてー」
 bawls, 'I can't believe I lost!'
+# 「負ーけーたー。」
 bawls, 'I've LOOOSST!'
 
 N:1152:Raiko
+# 「あらららら降参よー」
 says, 'My, my! I concede.'
+# 「道具って切ないわー」
 says, 'Poor sad tools...'
 
 N:1159:Medicine
+# 「ああもう……躰の修復に時間がかかりそう」
 says, 'Aah, geez. Repairing my body will take some time.'
 
 N:1161:Komachi
+# 「きゃん！」
 squeals, 'Kyan!'
 
 N:1226:Reimu
+# 「仕様が無いわね。悪巧みも程ほどにするのよ」
 says, 'So be it. Don't take your wicked scheming too far.'
+# 「今日は声が聞こえなかっただけだもん」
 says, 'I couldn't hear the gods' voices today, that's all.'
+# 「あいたー。落とし穴落下のダメージが今頃」
 says, 'Now I'm starting to feel the pain from the fall down here.'
+# 「あいたたた。」
 says, 'Ow, ow, ow!'
+# 「ようやっと敵を見つけたのに、こんなに出鱈目だなんて…」
 says, 'I finally found the enemy, but it's this absurd?'
+# 「にんげんむきのばしょではない！」
 says, 'This is no place for a human to be!'
+# 「出直すしかなさそう……」
 says, 'I guess I'll have to try again...'
 
-
 N:1227:Marisa
+# 「まぁ負けたんだから仕様が無い。帰って寝る。」
 says, 'Well, I lost, so there's nothing for it. Go home and sleep.'
+# 「負けたか……いつもより頑張ったんだがな」
 says, 'I lost even though I tried harder than usual...'
+# 「うわぁお前強いなぁ。」
 says, 'Uwah, you're really something.'
 
 N:1230:Mamizou
+# 「今日のところはこの位にしておいてやるぞい。」
 says, 'Let's leave it at that for today.'
+# 「降参じゃ！これ以上は明日に響く」
 says, 'I give up! Any more and I'll be feeling it tomorrow.'
 
 N:1267:Sumireko
+# 「やっぱり妖怪は怖かった……」
 says, 'Youkai are scary after all...'
 
 N:1268:Three Fairies
+# 「ぎゃん！(x3)」
 squeals, 'Kyan!' <x3>
 
 N:1273:Seiran
+# 「ぐうう、だから現地部隊は嫌だったのにー」
 says, 'Guuu, this is why I didn't want to be in the ground forces!'
 
 N:1274:Ringo
+# 「ああ、地上にもずいぶんと強い奴がいたもんね」
 says, 'Ahh, so there are some strong people on Earth too.'
 
 N:1275:Doremy
+# 「貴方の悪夢は私が美味しく頂きました」
 says, 'Your nightmares were delicious.'
 
 N:1276:Sagume
+# 「そんなに強いんですもの、貴方ならきっと……」
 says, 'This one is terribly powerful. Perhaps with you...'
 
 N:1277:Clownpiece
+# 「眠いよう、もう帰っていい？」
 says, 'I'm tired, can I go home already?'
+# 「もう力が残ってないや」
 says, 'I've run out of energy.'
 
 N:1297:Yorihime
 N:1298:Toyohime
-gasps, 'Gah...!'
+# 「ぎゃふん」
+gasps in disbelief.
 
 N:1299:Rei'sen
+# 「あの頃が懐かしい..」
 says, 'I miss my old life...'
 
 N:1310:Larva
+# 「こうさーん。」
 says, 'I sub-miiiit.'
+# 「負けたー。あんた、なかなかやるね！」
 says, 'I lose~. You sure are impressive!'
 
 N:1311:Nemuno
+# 「あんた強いな。何者なんだ？」
 says, 'You sure are tough! Who're you?'
+# 「強いやつは嫌いではない。うちに寄っていくか？」
 says, 'I can't not like strong folk! Wanna stop by my place?'
 
 N:1312:Aunn
+# 「負けたー。神社に尽くしてきたのにボコボコにされたー。」
 says, 'I've done my best for the shrine, but I got beaten up.'
+# 「暴力はんたーい。」
 says, 'I hate violence...'
 
 N:1313:Narumi
+# 「あらら、負けちゃった。」
 says, 'Oh my, I've lost.'
 
 N:1314:Satono
+# 「そうねぇ。及第点、かなぁ。」
 says, 'A passing grade, I guess.'
+# 「舐めてかかってたわね。」
 says, 'It seems I underestimated you.'
 
 N:1315:Mai
+# 「これは手強い。予想外だな。」
 says, 'Wow, you're super strong! I didn't expect that!'
+# 「よーし、おめでとう！　ごーかーく！」
 says, 'All right, congratulations! You paaaassed!'
 
 N:1316:Okina
+# 「やられたー！」
 says, 'I've been defeeeated!'
+# 「見事だ！素晴らしすぎる！」
 says, 'Brilliant! Magnificent!'
 
 N:1318:Kosuzu
+# を失神させて絵巻を奪った！
 loses consciousness, and the picture scroll tumbles away!
 
 N:1341:Eika
+# 「ぐぐぐ……強い。」
 says, 'Gugugu... so strong...'
+# 「うう……涙が止まらない。」
 says, 'Uuu... my tears won't stop.'
+# 「しくしくしく……。子供達が楽しみにしていた積み石コンテストが……。」
 bawls, 'The children were looking forward to the stone-stacking contest so much...'
 
 N:1342:Urumi
+# 「良いだろう。お前を河に沈めるのはやめてやる。」
 says, 'Okay. I'll stop trying to drown you.'
 
 N:1343:Kutaka
+# 「お、お見事です。そこまでの覚悟があるのなら、もう止めません。」
 says, 'W-Well done. If you're determined to go on, I won't keep you any longer.'
+# 「私は貴方のことを忘れます。鳥頭ですから。」
 says, 'I'll forget about you, because I'm a bird-brain.'
 
 N:1344:Yachie
+# 「キー！正々堂々じゃなければ有利に戦えるのに！」
 says, 'Ugh! I can't use my full potential in a fair fight!'
 
 N:1345:Mayumi
+# 「つ、強い！　畜生界の人間霊とは訳が違う……！」
 says, 'Such strength! Nothing like the human spirits from the Animal Realm!'
 
 N:1346:Keiki
+# 「私のファインセラミックスは傷つきもしないわ」
 says, 'My fine ceramics won't even be scratched.'
 
 N:1347:Saki
+# 「か、感動した！」
 says, 'Your performance, I'm, I'm moved!'
+# 「く、悔しくなんかない。」
 says, 'I- I regret nothing!'
+# 「どうだ、勁牙組に入って貰えないだろうか？」
 says, 'I wonder if you would consider joining the Keiga family?'
 
 N:1355:Miyoi
+# 「ひゃあ」
 says, 'Hi~yaa'
 
-
 N:1357:Mike
+# 「っく……！」
 sputters, 'Kku...!'
 
 N:1358:Takane
+# 「強すぎる……」
 says, 'Good grief...'
+# 「降参降参！だから降参だってばー！」
 says, 'I surrender, I surrender! I've been saying it all along!'
 
 N:1359:Sannyo
-says, 'Grh, you're too much...'
+# 「ぐ、強すぎる」
+snarls, 'Grh, you're too much...'
+# 「仕方が無い……降参だ」
 says, 'I have no choice... I give up.'
 
-
 N:1360:Misumaru
+# 「お見事！」
 says, 'Spectacular!'
+# 「やるじゃない」
 says, 'Not half bad.'
 
 N:1361:Tsukasa
+# 「ふにゅー」
 says, 'Funyuu~'
 
 N:1362:Megumu
+# 「ふっふっふ　お見事」
 says, 'Hehehe, splendid.'
+# 「強くて勇気のある者は好きです」
 says, 'I'm fond of those who are brave and powerful.'
 
 N:1364:Momoyo
+# 「思う存分弾幕を撃たせてくれてありがとう！」
 says, 'Thanks for letting me shoot all the danmaku I wanted!'
+# 「いつでも盗掘しに来い！」
 says, 'Come back and rob me any time!'
+# 「また勝負しようじゃないか！」
 says, 'Let's have a rematch!'
 
-
 N:1366:Yuuma
+# 「今回は負けを認めよう」
 says, 'I'll admit my loss this time.'
 
 N:1385:Enoko
+# 「つ、強い」
 says, 'Str... strong...'
 
 N:1386:Biten
-says, 'That was fun! Let's have a rematch!'
+# 「楽しかったよ！もう一戦しようよ」
+says, 'That was fun! Let's fight again!'
 
 N:1387:Chiyari
+# 「降参降参」
 says, 'I give, I give!'
 
 N:1388:Hisami
+# 「ああー強くて素敵だわー」
 says, 'Ahh, beautiful power.'
 
 N:*:Default lines

--- a/lib/file/monfear_gen_e.txt
+++ b/lib/file/monfear_gen_e.txt
@@ -1,4 +1,5 @@
 #monfear for Gensoukyou uniques
+#Some translations are sourced from community contributions to touhouwiki.net and thpatch.net
 
 N:1090:Cirno
 # 「く、も、もうそろそろかんべんしてー」

--- a/lib/file/monfear_gen_e.txt
+++ b/lib/file/monfear_gen_e.txt
@@ -1,147 +1,211 @@
 #monfear for Gensoukyou uniques
 
 N:1090:Cirno
+# 「く、も、もうそろそろかんべんしてー」
 says, 'Isn't- isn't it about time you gave me a break?'
+# 「わわわわわ！」
 screams, 'Wawawawawa!'
 
 N:1091:Meiling
+# 「くそ、背水の陣だ！」
 says, 'Damn. Time for my last stand battle formation!'
 
 N:1092:Patchouli
+# 「しくしく、貧血でスペルが唱え切れないの」
 sobs, 'I'm so anemic I can't finish reciting my spells.'
+# 「今日は厄日だわ！」
 says, 'This is the worst day ever!'
 
 N:1096:Letty
+# 「ちょい、待って！私は黒幕だけど、普通よ」
 says, 'No, wait! I'm the mastermind, but I'm normal!'
 
-
 N:1102:Youmu
+# 「幽々子さま、大変です。目を瞑ったら真っ暗です！」
 says, 'Oh no, Lady Yuyuko! When I close my eyes it goes completely dark!'
 
 N:1106:Wriggle
+# 「ひぇぇ」
 squeals, 'Eeek!'
 
 N:1107:Mystia
+# 「ここも駄目だ～！」
 says, 'This place is no good either~'
+# 「久しぶりのヒトネギだと思ったのに。あんた達、一体何者なのよ～」
 says, 'I thought a human had come carrying an onion. But who or what are you~?'
 
 N:1109:Tewi
-says, 'I can't afford to be captured~!'
+# 「捕まる訳にはいかないわー」
+says, 'I can't afford to be captured-!'
+# 「ちょっとちょっと。私が人を騙すような兎に見えます～？」
 says, 'Wait, wait, hold it. Do I look like a deceitful rabbit~?'
 
 N:1110:Udongein
+# 「早くここから脱出しないと……」
 says, 'I've got to get out of here fast...'
 
 N:1117:Nitori
+# 「ひゅい！？」
 shrieks, 'Hiiyui!?'
+# 「つ、強い。私の兵器で倒せないなんて……」
 says, 'You, you're too strong for my weapons...'
 
 N:1119:Aya
-says, 'Uncompromisingly accurate reportage is sometimes criticised.'
+# 「正確すぎる情報は、時として批難されるものです。」
+says, 'Uncompromisingly accurate reportage is sometimes criticized.'
+# 「もう……。善良な市民の味方を攻撃してどうするんですか」
 says, 'What are you doing, attacking an upstanding citizen?'
 
 N:1120:Sanae
+# 「何かヤバイ雰囲気……ひとまず退散して味方を呼んでこようかしら」
 says, 'There's a dangerous feeling... let's retreat and call my allies.'
+# 「お、おにょい？」
 says, 'Wha-wha-what?'
+# 「騙されたかもしれないわー！あのバカ狸にー！」
 says, 'I think I've been tricked! That stupid tanuki!'
 
 N:1129:Rin
+# 「何も企んでなんかないよー」
 says, 'I wasn't plotting anything!'
 
 N:1132:Nazrin
+# 「おおっと、私にはまだやるべき事がある。」
 says, 'Hey, I still have work to do.'
+# 「何にも隠し事なんかしてないってばよー」
 says, 'I'm telling you, I'm not hiding anything from you!'
 
 N:1133:Kogasa
+# 「さでずむ？」
 says, 'Sadism?'
+# 「ちくしょう！こうなったら神社に降りて暴れてやる」
 says, 'Damn! I ought to go down to the shrine and cause a mess!'
 
 N:1135:Murasa
+# 「な、お前ヤバくね？」
 says, 'Hey, you crazy?'
 
 N:1139:Kyouko
+# 「私を倒しても何にもならないわよー」
 says, 'Beating me won't do any good, you know...'
+# 「不肖ヤマビコ、まだまだ修行が足りないわ！」
 says, 'Oh, this unworthy yamabiko still lacks training!'
 
 N:1143:Futo
+# 「何だと？おぬし、ただ者ではないな？」
 says, 'What! Thou art no mundane creature.'
+# 「くっ！おぬしは何者だ？」
 says, 'Kuh! What manner of being art thou?'
+# 「くっ。おぬし、鍛えているな？」
 says, 'Ugh! Thou hast conditioned thy body?'
 
 N:1146:Banki
+# 「な、なによあんた。強いじゃないのよ」
 says, 'Wha, what's with you? You're actually strong.'
+# 「く、くやしいけど、ここは大人しく退くか……」
 says, 'Unfortunate, but I guess I'll take a step back for now...'
 
 N:1147:Kagerou
+# 「ひえー」
 squeals, 'Eek!'
 
 N:1149:Yatsuhashi
+# 「わーお、こりゃ無理だー」
 says, 'Wow, I can't stand up to this!'
 
 N:1150:Seija
+# 「まだだ、まだ諦めないぞ！」
 says, 'Not yet! I haven't given up yet!'
+# 「こんなところまで追手が……」
 says, 'Has my infamy already spread so far?'
 
 N:1152:Raiko
+# 「まだまだ使いこなせてないかなぁ」
 says, 'I'm still no master of the art.'
 
 N:1158:Kokoro
+# 「怖い……この人怖いよう」
 says, 'Scary... this person is scary.'
 
-
-
 N:1161:Komachi
+# 「いかん。こんな所で油を売っている場合ではない」
 says, 'This is bad. I can't be wasting time here.'
+# 「じゃ、あたいはこれにて……仕事があるんでねぇ」
 says, 'Well, I'll be off then... I have a job, you know...'
 
 N:1227:Marisa
+# 「くそ、一体、何だと言うんだ？」
 says, 'Damn it, what the hell do you mean?'
+# 「なん……だと？」
 says, 'What the...?'
+# 「判らん判らん。一体何が起きてるんだ？」
 says, 'I don't understand! What the hell is happening!?'
+# 「なんと……こんなに強かったなんて、これはやばいな」
 says, 'What...? You're that strong? This is nuts.'
 
 N:1267:Sumireko
+# 「逃げなきゃ外の世界へ早く！」
 says, 'I have to escape to the peaceful Outside World!'
+# 「ねえもう許してよう」
 says, 'Forgive me already!'
+# 「ひえー何で攻撃してくるのー」
 says, 'Eek, why are you attacking me!?'
 
 N:1268:Three Fairies
-says, 'Waaaatsu!?'
+# 「わぁっ！？」
+yells, 'Waaaatsu!?'
+# 「ごめんなさいごめんなさーい！」
 says, 'We're sorry we're sorry!'
+# 「てっ…撤収ーっ！！」
 says, 'Re, retreat!!'
+# 「なによスターちゃんと……っていないし！」
 says, 'Star, why didn't... she's gone!?'
 
 N:1273:Seiran
+# 「地上人つよいじゃーんやだー」
 says, 'The earthlings are too strong!'
+# 「やだー何で援軍が誰も来ないのよー」
 says, 'Where are my damn reinforcements?'
+# はどこかに救難信号を送っている。
 is sending a distress signal.
 
 N:1277:Clownpiece
+# 「な、なんで……？」
 says, 'W, why...?'
+# 「話が違うわよー」
 says, 'Nobody told me this would happen.'
 
 N:1299:Rei'sen
+# は震えながら何かをつぶやいている。
 is trembling and muttering something.
 
 N:1320:Shion
+# 「私だって好きで貧乏している訳じゃないのにー。」
 says, 'It's not like I want to be poor.'
 
 N:1342:Urumi
+# 「なんだ強いじゃないか。折角、古代魚達の餌にしてやろうと思ったのに。」
 says, 'Too bad, I wanted to feed you to my ancient fish.'
 
 N:1343:Kutaka
+# 「何なのよーあんた達は」
 says, 'What on earth are you!?'
+# 「説明がなさ過ぎて困ります」
 says, 'I'm finding this rather confusing.'
 
 N:1345:Mayumi
+# 「なんと恐ろしい策！」
 says, 'What a fearsome strategy!'
+# 「夢のような現実だわ！」
 says, 'Feels like I'm living in a dream!'
 
 N:1355:Miyoi
+# 「ふえぇ」
 says, 'Fueeh~'
+# (GYO!?)
 makes a GYO!?
 
 N:1361:Tsukasa
+# 「はあ、これは参った」
 says, 'Haa, this is bad.'
 
 N:*:Default lines

--- a/lib/file/monfear_gen_e.txt
+++ b/lib/file/monfear_gen_e.txt
@@ -54,7 +54,7 @@ N:1119:Aya
 # 「正確すぎる情報は、時として批難されるものです。」
 says, 'Uncompromisingly accurate reportage is sometimes criticized.'
 # 「もう……。善良な市民の味方を攻撃してどうするんですか」
-says, 'What are you doing, attacking an upstanding citizen?'
+says, 'What are you doing, attacking an ally of upstanding citizens?'
 
 N:1120:Sanae
 # 「何かヤバイ雰囲気……ひとまず退散して味方を呼んでこようかしら」

--- a/lib/file/monfear_gen_e.txt
+++ b/lib/file/monfear_gen_e.txt
@@ -152,7 +152,7 @@ says, 'Eek, why are you attacking me!?'
 
 N:1268:Three Fairies
 # 「わぁっ！？」
-yells, 'Waaaatsu!?'
+yells, 'Waaaaa!?'
 # 「ごめんなさいごめんなさーい！」
 says, 'We're sorry we're sorry!'
 # 「てっ…撤収ーっ！！」
@@ -190,7 +190,7 @@ N:1343:Kutaka
 # 「何なのよーあんた達は」
 says, 'What on earth are you!?'
 # 「説明がなさ過ぎて困ります」
-says, 'I'm finding this rather confusing.'
+says, 'I'm finding this situation rather confusing.'
 
 N:1345:Mayumi
 # 「なんと恐ろしい策！」

--- a/src/do-spell.c
+++ b/src/do-spell.c
@@ -18400,7 +18400,7 @@ static cptr do_new_spell_necromancy(int spell, int mode)
 		if (name) return "怨霊憑依";
 		if (desc) return "モンスター一体に怨霊を憑依させ、高確率で狂戦士化させる。抵抗されると無効。妖怪に効きやすいが通常の精神を持たないモンスターには効かない。";
 #else
-		if (name) return "Vengeful Spirit Possession";
+		if (name) return "Incite Possession";
 		if (desc) return "Makes a single monster possessed a vengeful spirit, making it berserk with a high probability rate. Does nothing if resisted. Works well against youkai, but does not affect monsters with unusual mind.";
 #endif
 
@@ -20097,7 +20097,7 @@ static cptr do_new_spell_transform(int spell, int mode)
 
 		if (desc) return "一定時間回復力が強化され、さらに毒に対する耐性を得る。";
 #else
-		if (name) return "Transform Circulatory Organs";
+		if (name) return "Transform Vascular System";
 		if (desc) return "Grants temporary regeneration and resistance to poison.";
 #endif
 
@@ -24463,8 +24463,8 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "天石門別命降臨";
 		if (desc) return "天石門別命(あまのいわとわけのみこと)をその身に降ろし、周囲全ての地形、アイテム、モンスターを消失させる。";
 #else
-		if (name) return "Descent of Ama-no-Iwato-Wake-no-Mikoto";
-		if (desc) return "Become possessed by Ama-no-Iwato-Wake-no-Mikoto; wipes away all terrain, items and monsters in your vicinity.";
+		if (name) return "Ama-no-Iwatowake";
+		if (desc) return "Become possessed by Ama-no-Iwatowake-no-Mikoto; wipes away all terrain, items and monsters in your vicinity.";
 #endif
 		{
 			int rad = 3 + plev / 4;
@@ -24483,7 +24483,7 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "石凝姥命降臨";
 		if (desc) return "石凝姥命(いしこりどめのみこと)をその身に降ろす。一定時間、閃光攻撃に対する完全な免疫と反射能力を得る。";
 #else
-		if (name) return "Descent of Ishikori-dome-no-Mikoto";
+		if (name) return "Ishikori-dome";
 		if (desc) return "Become possessed by Ishikori-dome-no-Mikoto. Grants temporary immunity to light and reflection.";
 #endif
 
@@ -24504,8 +24504,8 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "飯綱権現降臨";
 		if (desc) return "飯綱権現(いづなごんげん)をその身に降ろす。一定時間、直接攻撃によって混沌の勢力のモンスターに大きなダメージを与えられるようになる。";
 #else
-		if (name) return "Descent of Izuna-Gongen";
-		if (desc) return "Become possessed by Izuna-Gongen. Temporarily makes your melee attacks deal extra damage to chaotically aligned monsters.";
+		if (name) return "Izuna Gongen";
+		if (desc) return "Become possessed by Izuna Gongen. Temporarily makes your melee attacks deal extra damage to chaotically aligned monsters.";
 #endif
 
 		{
@@ -24515,14 +24515,14 @@ static cptr do_new_spell_punish(int spell, int mode)
 
 			if (cast)
 			{
-				msg_print(_("飯縄権現の護法の力が身に宿った！", "The power of Izuna-Gongen resides in your body!"));
+				msg_print(_("飯縄権現の護法の力が身に宿った！", "The power of Izuna Gongen resides in your body!"));
 				set_kamioroshi(KAMIOROSHI_IZUNA, randint1(base) + base);
 			}
 		}
 		break;
 
 	case 27:
-		if (name) return _("伊豆能売降臨", "Descent of Izunome");
+		if (name) return _("伊豆能売降臨", "Izunome");
 		if (desc) return _("伊豆能売(いづのめ)をその身に降ろし、視界内全てに対して強力な破邪属性攻撃を行い、さらに呪われた装備を解呪する。",
                             "Become possessed by Izunome; hits everything in sight with a powerful holy attack, and removes curses from your equipment.");
 		{
@@ -24550,7 +24550,7 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "住吉三神降臨";
 		if (desc) return "上筒男命（うわつつのおのみこと）、中筒男命（なかつつのおのみこと）、底筒男命（そこつつのおのみこと）をその身に降ろす。一定時間、加速、高速移動能力、水耐性、時空攻撃耐性、警告を得る。";
 #else
-		if (name) return "Descent of Sumiyoshi Sanjin";
+		if (name) return "Sumiyoshi Sanjin";
 		if (desc) return "Become possessed by Uwatsutsu-no-O-no-Mikoto, Nakatsutsu-no-O-no-Mikoto and Sokotsutsu-no-O-no-Mikoto. Grants temporary haste, swift movement, resistance to water and time, and warning.";
 #endif
 
@@ -24573,8 +24573,8 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "愛宕権現降臨";
 		if (desc) return "愛宕権現（あたごごんげん）をその身に降ろす。一定時間、炎に対する完全な免疫と強力な火炎のオーラを得て火炎属性攻撃ができるようになる。";
 #else
-		if (name) return "Descent of Atago-Gongen";
-		if (desc) return "Become possessed by Atago-Gongen. Grants temporary immunity to fire, strong fire aura and ability to use fire attacks.";
+		if (name) return "Atago Gongen";
+		if (desc) return "Become possessed by Atago Gongen. Grants temporary immunity to fire, strong fire aura and ability to use fire attacks.";
 #endif
 
 		{
@@ -24584,7 +24584,7 @@ static cptr do_new_spell_punish(int spell, int mode)
 
 			if (cast)
 			{
-				msg_print(_("愛宕様の神火が身に宿った！", "Divine flame of Atago-Gongen resides in your body!"));
+				msg_print(_("愛宕様の神火が身に宿った！", "Divine flame of Atago Gongen resides in your body!"));
 				set_kamioroshi(KAMIOROSHI_ATAGO, randint1(base) + base);
 			}
 		}
@@ -24595,7 +24595,7 @@ static cptr do_new_spell_punish(int spell, int mode)
 		if (name) return "天宇受売命降臨";
 		if (desc) return "天宇受売命（あめのうずめのみこと）をその身に降ろす。一定時間、暗黒・地獄・地獄の業火属性の攻撃への耐性、AC上昇、魔法防御上昇、魅力大幅上昇を得る。";
 #else
-		if (name) return "Descent of Ame-no-Uzume-no-Mikoto";
+		if (name) return "Ame-no-Uzume";
 		if (desc) return "Become possessed by Ame-no-Uzume-no-Mikoto. Grants temporary resistance to darkness, nether and hellfire, raises AC and protection from magic, and greatly raises charisma.";
 #endif
 
@@ -24614,7 +24614,7 @@ static cptr do_new_spell_punish(int spell, int mode)
 
 
 	case 31:
-		if (name) return _("天照大御神降臨", "Descent of Amaterasu Oomikami");
+		if (name) return _("天照大御神降臨", "Amaterasu Oomikami");
 		if (desc) return _("天照大御神(あまてらすおおみかみ)をその身に降ろし、周囲の敵に大打撃を与える。自分の近くにいるモンスターほど効果が大きい。天宇受売命を降ろしているときに使うとさらに効果が増す。",
                             "Become possessed by Amaterasu Oomikami. Delivers severe damage to enemies in your vicinity; deals more damage to nearby monsters. Even more effective if used while being possessed by Ame-no-Uzume-no-Mikoto.");
 		{
@@ -25410,7 +25410,7 @@ static cptr do_new_spell_occult(int spell, int mode)
 		break;
 
 	case 17:
-		if (name) return _("人体発火現象", "Spontaneous Human Combustion");
+		if (name) return _("人体発火現象", "Spontan. Human Combustion");
 		if (desc) return _("周囲のランダムな生物一体の場所に強力なプラズマ属性の球が発生する。",
                             "Generates a powerful ball of plasma on top of a random nearby living being.");
 		{


### PR DESCRIPTION
- Add untranslated lines to English speech files as comments. Add a note of attribution to other community projects to the speech files.
- Compromise spell names so they fit the 25 character limit.
Vengeful Spirit Possession → Incite Possession
Transform Circulatory Organs → Transform Vascular System
Spontaneous Human Combustion → Spontan. Human Combustion (no good options for this one)
Heavenly descent spells → abbreviated to just the god's name
- Correct some monster/item descriptions. (Including Keiki's name, I thought it always being in quotes was indicating doing something cute, but I've decided my approach to it was stupid)
- Insect Sake → Sake Bug Sake
Seems "Wine Worm" was a chosen translation in the Touhou community at one point, and that also has some historical precedence, but "Sake Bug" stuck for whatever reason. Up to you I guess.
- Ultrasonic Whistle → Ultrasonic Sleeping Cat
It's literally shaped like a cat
- Minor changes/proofreading