### PR TITLE
English: do not make a unique's name plural in probing message

### DIFF
--- a/src/spells2.c
+++ b/src/spells2.c
@@ -5945,8 +5945,10 @@ bool probing(void)
 				/* Note that we learnt some new flags  -Mogami- */
 				msg_format("%s‚É‚Â‚¢‚Ä‚³‚ç‚ÉÚ‚µ‚­‚È‚Á‚½‹C‚ª‚·‚éB", buf);
 #else
-				/* Pluralize it */
-				plural_aux(buf);
+				if (!(r_ptr->flags1 & RF1_UNIQUE)) {
+					/* Pluralize it */
+					plural_aux(buf);
+				}
 
 				/* Note that we learnt some new flags  -Mogami- */
 				msg_format("You now know more about %s.", buf);


### PR DESCRIPTION
Backported from Hengband 3's https://github.com/hengband/hengband/commit/db5987167b658b3f5d4ee4535dc854e9135afd1c .