### PR TITLE
Speech translations, minor bug fixes

### DIFF
--- a/lib/file/mondeath_gen_e.txt
+++ b/lib/file/mondeath_gen_e.txt
@@ -273,8 +273,9 @@ N:1297:Yorihime
 # 「ぎゃふん」
 gasps in disbelief.
 
-N:1298:
+N:1298:Toyohime
 #「後は、任せましたよ。私に会ったことは内緒にしてね」
+says, 'The rest I'll leave to you. And do keep our encounter a secret, would you?'
 
 N:1299:Rei'sen
 # 「あの頃が懐かしい..」
@@ -426,21 +427,27 @@ N:1388:Hisami
 # 「ああー強くて素敵だわー」
 says, 'Ahh, beautiful power.'
 
-N:1409:チミ
+N:1409:Chimi
 #「これでも昔はのう...」
+says, 'Back in the old days...'
 
-N:1410:馴子
+N:1410:Nareko
 #「神聖なる謎かけを冒涜しやがって...」
+says, 'You desecrator of the sacred riddles...'
 
-N:1411:ユイマン
+N:1411:Yuiman
 #「また遊びに来てねー」
+says, 'Please visit again some time!'
 #「今度、一緒に鹿狩りでもしましょ？」
+says, 'Next time, why don't we go deer hunting together?'
 
-N:1412:阿梨夜
+N:1412:Ariya
 #「貴方のお陰で、仕事を休めるわ。ありがとう」
+says, 'Thanks to you, I can take some time off work. Thank you.'
 
-N:1413:ニナ
+N:1413:Nina
 #「まさか、真実が敗れるなんて」
+says, 'No way, that the truth could lose!'
 
 
 N:*:Default lines

--- a/lib/file/monspeak_gen_e.txt
+++ b/lib/file/monspeak_gen_e.txt
@@ -1891,8 +1891,8 @@ says, 'The power of perpetuity that can engulf transformation itself!'
 says, 'To be selfishly confined in a place like this.'
 #「石という物は不変の象徴です」
 says, 'A stone is a symbol of the unchanging.'
-#「程度のならそれまでのこと」
-says, 'If that's all, then there's nothing to it.'
+#「あんな石にやられる程度のならそれまでのこと」
+says, 'If those stones were enough to stop you, then you would've deserved it.'
 #「私は不変の神なのです。だから、私は変に非ず」
 says, 'I am the god of the unchanging. I cannot be unusual.'
 

--- a/lib/file/monspeak_gen_e.txt
+++ b/lib/file/monspeak_gen_e.txt
@@ -203,6 +203,7 @@ says, 'May I borrow a little of your time?'
 # 「その優しい火が～♪命取られて消えていく～♪」
 croons, 'That gentle flame~, its life is taken and winks out~'
 #「イエス！説明してほしいのね！」
+says, 'Yes! Your wanted explanation!'
 
 N:1106:Wriggle
 # 「蛍様が出て喜ばない奴なんて、久しぶりに見たよ！」
@@ -496,7 +497,9 @@ says, 'Now, sleep with this trauma that will leave you sleepless!'
 # 「あ、今もっと強い技を思い出したわね？ふむふむ、参考にしておくわ。」
 says, 'Oh, you remembered a stronger technique? Hmm-hmm, I'll have to take another look.'
 #「……なるほど、そういう事だったのね」
+says, '...I see, so that's the way it was.'
 #「どれどれ…」
+says, 'Well, well...'
 
 N:1129:Rin
 # 「楽しいことしてるね！あたいも混ぜてくれるかい？」
@@ -554,6 +557,7 @@ says, 'Hello hello, where do you think I am right now?'
 # 「あら、ここは何処かしら？」
 says, 'Huh, where am I?'
 #「透明人間はのんきなもんだー」
+sings, 'The invisible man is carefree~'
 
 N:1132:Nazrin
 # 「どうやら宝の反応は君だったみたいだ。」
@@ -1051,6 +1055,7 @@ says, 'There you are, you youkai!'
 # 「これで神社が少し大きくなるわ」
 says, 'This will make the shrine a little bigger.'
 #「ひと言言いたい。迷路がすぎる！」
+says, 'I'll say just one thing. This is way too much of a maze!'
 
 
 N:1227:Marisa
@@ -1105,7 +1110,10 @@ says, 'I'm just, uh, investigating the enigma of the Black Markets!'
 # 「こりゃ阻止しないといけないな！今ここで！」
 says, 'I have to stop this! Right here and right now!'
 #「わざとらしいほどに複雑な構造だ」
+says, 'This is such a convoluted structure.'
 #「この攻撃の激しさは新しい異変(エキストラ)を感じさせる」
+says, 'The intensity of these attacks make it feel like an extra incident has begun.'
+
 
 N:1230:Mamizou
 # 「壮大な狸囃子の始まりじゃ！」
@@ -1257,7 +1265,7 @@ is scowling in the wrong direction...
 # 「地上の美しさは穢れに由来するのはよく判った。だがまだ死への恐れが足りない様だな。」
 says, 'I understand that the beauty of the Earth arises from its impurity. But it seems you lack sufficient fear of death.'
 # 「死を恐れよ。命を惜しめ。人間も妖怪も生命を感じる事で我々にひれ伏すしか無くなるのだから。」
-says, 'Fear death. Treasure life. Be it human or youkai, those who value life must bow to us. Because it will disappear.'
+says, 'Fear death. Treasure life. Be it human or youkai, those who value life must bow to us. For it will disappear.'
 
 N:1279:Hecatia
 N:1280:
@@ -1313,9 +1321,13 @@ says, 'Child of a filthy world, impure body commanded by malice, this is not you
 # は桃を頬張っている。
 is stuffing herself with peaches.
 #「そこまでよ。貴方に勝ち目はない」
+says, 'That's enough. You have no chance of winning.'
 #「最初に私に会った幸運に感謝する事ね！」
+says, 'You should be grateful for your luck in meeting me so soon!'
 #「せんないねぇ」
+says, 'There's nothing for it.'
 #は手の扇で顔を隠している。
+hides her face with the fan in her hand.
 
 N:1299:Rei'sen
 # は半ば逃げ腰で銃を構えている。
@@ -1583,6 +1595,7 @@ says, 'I'll show you the best power and speed in the Animal Realm!'
 # 「お前の強さなら最初から幹部でも良いぞ」
 says, 'With that might of yours, you could start at a high rank right away.'
 #「勁牙組の早鬼だ。組長だ！ひれふせい！」
+says, 'Saki of the Keiga Family. The Boss! Prostrate yourself!'
 
 
 N:1355:Miyoi
@@ -1761,6 +1774,7 @@ says, 'I'll capture you and enlist you in the Keiga Family.'
 # 「いざ勝負だ！よく噛んで死ねい！」
 says, 'The fight begins! I'll grind you to death with my fangs!'
 #「そこあぶないよー」
+says, 'Watch your step, it's dangerous!'
 # は両手のトラバサミを鳴らしている。
 makes snapping noises with the beartraps on her arms.
 
@@ -1816,52 +1830,87 @@ says, 'Overcome this fantasy with all your might!'
 # 「選ぶがいい。全てを忘れるか、無に帰すかを！」
 says, 'Make your choice. Forget everything, or become nothing!'
 
-N:1408:ウバメ
+N:1408:Ubame
 #は天に向かって拳を突き上げた。
+raises a fist skyward.
 #「こんな事をしたのはそこのお前か」
+says, 'You there, are you responsible for all this?'
 #「訳わからんことするな」
+says, 'Don't waste time with incomprehensible things.'
 #「さっさと聖域を元に戻せ」
+says, 'Hurry up and fix the sanctuary!'
 
-N:1409:チミ
+N:1409:Chimi
 #の姿が一瞬渦のようにぼやけた。
+momentarily blurs and swirls like a vortex.
 #「ったく今の若いもんは」
+says, 'Good grief, young people these days.'
 #「これだから...」
+says, 'That's because...'
 
-N:1410:馴子
+N:1410:Nareko
 #「え？盗掘しに来たの？」
+says, 'Huh? You came here to loot?'
 #「別に良いのよ？盗掘が夢でも何でも」
+says, 'Tomb robbery or dreaming of tomb robbery or whatever, it's okay, yeah?'
 #「ワクワクするぜー」
+says, 'I'm so thrilled~'
 #楽しげに杖を振っている。
+waves her scepter cheerfully.
 #「あまりにも仕事がなくて退屈していたんだから」
+says, 'Nothing's been happening and I was getting so bored.'
 #「へー、へー」
+says, 'Oh? Oohh?'
 #「答えられなかったお前はここで死ぬ運命にある！」
+says, 'You didn't have the right answer, so you're destined to die here!'
 
-N:1411:ユイマン
+N:1411:Yuiman
 #「これはまた人間そっくりね。しかし、よく見ると綻びも多い」
+says, 'This one is very human-like. But look closely enough, and it has many flaws.'
 #「いくら人間の形に見えても貴方は模造人間だ」
+says, 'No matter how human you look, you're a hallucinatory human!'
 #「それが初対面にする挨拶か？」
+says, 'Is that the way you're supposed to greet someone you've just met?'
 #「貴方のその好戦的な性格は典型的なゲームキャラクターと呼ばれる者」
+says, 'Your combative personality is typical of a game character.'
 #「貴方を直さないといけないね！」
+says, 'I must fix you!'
 #「私は惑わされない」
+says, 'I won't be fooled by you.'
 
-N:1412:阿梨夜
+N:1412:Ariya
 #「やっと来た」
+says, 'Finally you have arrived.'
 #「そう来なくっちゃ」
+says, 'Now that's the spirit.'
 #「残りは少ないよ貴方の寿命...」
+says, 'Little of your lifetime remains...'
 #「変容すら呑み込む恒久の力だ！」
+says, 'The power of perpetuity that can engulf transformation itself!'
 #「私をこんな場所に閉じ込めておいて勝手なもんよね」
+says, 'To be selfishly confined in a place like this.'
 #「石という物は不変の象徴です」
-#「あんな石にやられる程度のならそれまでのこと」
+says, 'A stone is a symbol of the unchanging.'
+#「程度のならそれまでのこと」
+says, 'If that's all, then there's nothing to it.'
 #「私は不変の神なのです。だから、私は変に非ず」
+says, 'I am the god of the unchanging. I cannot be unusual.'
 
-N:1413:ニナ
+N:1413:Nina
 #「誰が怪物よ、貝だけど」
+says, 'Who's the monster? I'm just a clam.'
 #「まだ目覚めていないようね　可哀想に」
+says, 'It seems you haven't woken up yet. Poor soul.'
 #「情報は武器なのよ。武器はただの道具。それ以上でもそれ以下でもないわ」
+says, 'Information is a weapon. Weapons are just tools. No more or less.'
 #「真実を浴びて目覚めよ！私の蜃気楼で！」
+says, 'Bathe in the truth and wake up! Through my mirage!'
 #「マジだよ」
+says, 'It's true.'
 #「私は全てを知るもの」
+says, 'I am the all-knowing one.'
 #「それは闇の勢力側が隠しているからよ！」
+says, 'The forces of darkness are hiding the truth!'
 
 N:*:Default lines
 #Gensoukyou uniques have no default lines

--- a/src/cmd4.c
+++ b/src/cmd4.c
@@ -4960,7 +4960,7 @@ static cptr do_cmd_feeling_text[11] =
 	//"‹°‚ë‚µ‚¢€‚ÌŒ¶‚ª–Ú‚É•‚‚©‚ÑA‹Câ‚µ‚»‚¤‚É‚È‚Á‚½I",
 
 #else
-	"You nearly faint as horrible visions of death fill your mind!",
+	"An unbelievable situation is unfolding on this level!",
 #endif
 
 #ifdef JP

--- a/src/object1.c
+++ b/src/object1.c
@@ -844,9 +844,12 @@ bool screen_object(object_type *o_ptr, u32b mode)
 			info[i] = &temp2[j]; i++;
 		}
 #ifndef JP
-		if(o_ptr->pval >= 0 && o_ptr->pval < ABILITY_CARD_LIST_LEN && ability_card_list[o_ptr->pval].activate)
+		if (p_ptr->pclass != CLASS_CHIMATA)
 		{
-			info[i++] = item_activation_chance(o_ptr);
+			if(o_ptr->pval >= 0 && o_ptr->pval < ABILITY_CARD_LIST_LEN && ability_card_list[o_ptr->pval].activate)
+			{
+				info[i++] = item_activation_chance(o_ptr);
+			}
 		}
 #endif
 	}

--- a/src/spells3.c
+++ b/src/spells3.c
@@ -8456,8 +8456,13 @@ void	search_specific_monster(int mode)
 	}
 	else
 	{
+		#ifdef JP
 		char msg_mode[40];
 		char msg_dist[16];
+		#else
+		char msg_mode[40];
+		char msg_dist[26];
+		#endif
 
 		if (mode == 1) my_strcpy(msg_mode, _("”ñ“úí‚Ì—\’›", "something out of the ordinary"), sizeof(msg_mode) - 2);
 


### PR DESCRIPTION
- Translate new speak/death lines
- Translate replacement for the "horrible visions of death..." level feeling
- Hide ability card activation odds for Chimata as she uses a non-standard formula, and the correct fail rates are already displayed in the J menus
- Fix truncation of message when using Danmaku Hoarder

By the way, would you be interested in a birth option that auto-identifies items? I already have code for identifying every item on the ground (replacing the old commented-out pre-compile setting), I can turn that into a feature if you want.